### PR TITLE
Feature/mobile nav

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,15 +1,13 @@
-import { Button, Card } from "@heroui/react";
+import { Card } from "@heroui/react";
 
-import { PanelRightIcon } from "lucide-react";
+import { MobileNav } from "@/features/dashboard";
 
 export default function DashboardPage() {
   return (
     <>
       <header className="flex items-center justify-between py-5">
         <h1 className="font-semibold">Dashboard</h1>
-        <Button type="button" variant="ghost" size="sm" isIconOnly className="md:hidden">
-          <PanelRightIcon />
-        </Button>
+        <MobileNav />
       </header>
       <main className="flex flex-col gap-5">
         <div className="grid gap-5 sm:grid-cols-2">

--- a/src/features/auth/hooks/use-sign-out.tsx
+++ b/src/features/auth/hooks/use-sign-out.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { client } from "@/features/auth";
+
+export default function useSignOut() {
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    try {
+      const { data, error } = await client.signOut();
+
+      if (!data?.success) {
+        throw error;
+      }
+
+      router.refresh();
+    } catch (error) {
+      console.error(error);
+
+      // Inform the user of the error
+    }
+  };
+
+  return {
+    signOut: handleSignOut,
+  };
+}

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -6,4 +6,6 @@ export { authenticateUser } from "./lib/actions";
 
 export { MIN_PASSWORD, MAX_PASSWORD } from "./lib/constants";
 
+export { default as useSignOut } from "./hooks/use-sign-out";
+
 export { default as LoginForm } from "./components/login-form";

--- a/src/features/dashboard/components/mobile-nav-menu.tsx
+++ b/src/features/dashboard/components/mobile-nav-menu.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+
+import { useRouter } from "next/navigation";
+
+import { Dropdown, Label } from "@heroui/react";
+
+import { FolderGit2Icon, LogOutIcon } from "lucide-react";
+
+import { GITHUB_REPO } from "@/lib/constants";
+
+import { client } from "@/features/auth";
+
+import { getNavIcon, mobileNavItems } from "@/features/dashboard";
+
+export default function MobileNavMenu() {
+  const router = useRouter();
+
+  return (
+    <Dropdown.Menu>
+      {mobileNavItems.map((navItem) => {
+        const Icon = getNavIcon(navItem.label);
+
+        return (
+          <Dropdown.Item
+            key={navItem.id}
+            textValue={navItem.label}
+            className="capitalize"
+            href={navItem.href}
+            render={(props) => ("href" in props ? <Link {...props}></Link> : <div {...props}></div>)}
+          >
+            <Icon className="text-muted size-4" />
+            <Label>{navItem.label}</Label>
+          </Dropdown.Item>
+        );
+      })}
+      <Dropdown.Item id="github" textValue="GitHub" href={GITHUB_REPO} target="_blank" rel="noopener noreferrer">
+        <FolderGit2Icon className="text-muted size-4" />
+        <Label>GitHub</Label>
+      </Dropdown.Item>
+      <Dropdown.Item
+        id="signout"
+        textValue="Sign Out"
+        variant="danger"
+        onAction={async () => {
+          try {
+            const { data, error } = await client.signOut();
+
+            if (!data?.success) {
+              throw error;
+            }
+
+            router.refresh();
+          } catch (error) {
+            console.error(error);
+
+            // Inform the user of the error
+          }
+        }}
+      >
+        <LogOutIcon className="text-muted size-4" />
+        <Label>Sign Out</Label>
+      </Dropdown.Item>
+    </Dropdown.Menu>
+  );
+}

--- a/src/features/dashboard/components/mobile-nav-menu.tsx
+++ b/src/features/dashboard/components/mobile-nav-menu.tsx
@@ -2,20 +2,18 @@
 
 import Link from "next/link";
 
-import { useRouter } from "next/navigation";
-
 import { Dropdown, Label } from "@heroui/react";
 
 import { FolderGit2Icon, LogOutIcon } from "lucide-react";
 
 import { GITHUB_REPO } from "@/lib/constants";
 
-import { client } from "@/features/auth";
+import { useSignOut } from "@/features/auth";
 
 import { getNavIcon, mobileNavItems } from "@/features/dashboard";
 
 export default function MobileNavMenu() {
-  const router = useRouter();
+  const { signOut } = useSignOut();
 
   return (
     <Dropdown.Menu>
@@ -39,26 +37,7 @@ export default function MobileNavMenu() {
         <FolderGit2Icon className="text-muted size-4" />
         <Label>GitHub</Label>
       </Dropdown.Item>
-      <Dropdown.Item
-        id="signout"
-        textValue="Sign Out"
-        variant="danger"
-        onAction={async () => {
-          try {
-            const { data, error } = await client.signOut();
-
-            if (!data?.success) {
-              throw error;
-            }
-
-            router.refresh();
-          } catch (error) {
-            console.error(error);
-
-            // Inform the user of the error
-          }
-        }}
-      >
+      <Dropdown.Item id="signout" textValue="Sign Out" variant="danger" onAction={async () => await signOut()}>
         <LogOutIcon className="text-muted size-4" />
         <Label>Sign Out</Label>
       </Dropdown.Item>

--- a/src/features/dashboard/components/mobile-nav.tsx
+++ b/src/features/dashboard/components/mobile-nav.tsx
@@ -6,7 +6,7 @@ import { MobileNavMenu, UserProfile } from "@/features/dashboard";
 
 export default function MobileNav() {
   return (
-    <nav>
+    <nav role="Navigation">
       <Dropdown>
         <Tooltip delay={0} closeDelay={0}>
           <Button type="button" variant="ghost" size="sm" isIconOnly className="md:hidden">

--- a/src/features/dashboard/components/mobile-nav.tsx
+++ b/src/features/dashboard/components/mobile-nav.tsx
@@ -1,6 +1,6 @@
 import { PanelRightIcon } from "lucide-react";
 
-import { Button, Dropdown } from "@heroui/react";
+import { Button, Dropdown, Tooltip } from "@heroui/react";
 
 import { MobileNavMenu, UserProfile } from "@/features/dashboard";
 
@@ -8,9 +8,15 @@ export default function MobileNav() {
   return (
     <nav>
       <Dropdown>
-        <Button type="button" variant="ghost" size="sm" isIconOnly className="md:hidden">
-          <PanelRightIcon />
-        </Button>
+        <Tooltip delay={0} closeDelay={0}>
+          <Button type="button" variant="ghost" size="sm" isIconOnly className="md:hidden">
+            <PanelRightIcon />
+          </Button>
+          <Tooltip.Content showArrow>
+            <Tooltip.Arrow />
+            <p>Navigation</p>
+          </Tooltip.Content>
+        </Tooltip>
         <Dropdown.Popover>
           <div className="px-3">
             <UserProfile />

--- a/src/features/dashboard/components/mobile-nav.tsx
+++ b/src/features/dashboard/components/mobile-nav.tsx
@@ -6,10 +6,10 @@ import { MobileNavMenu, UserProfile } from "@/features/dashboard";
 
 export default function MobileNav() {
   return (
-    <nav role="Navigation">
+    <nav role="Navigation" className="md:hidden">
       <Dropdown>
         <Tooltip delay={0} closeDelay={0}>
-          <Button type="button" variant="ghost" size="sm" isIconOnly className="md:hidden">
+          <Button type="button" variant="ghost" size="sm" isIconOnly>
             <PanelRightIcon />
           </Button>
           <Tooltip.Content showArrow>

--- a/src/features/dashboard/components/mobile-nav.tsx
+++ b/src/features/dashboard/components/mobile-nav.tsx
@@ -17,7 +17,7 @@ export default function MobileNav() {
             <p>Navigation</p>
           </Tooltip.Content>
         </Tooltip>
-        <Dropdown.Popover>
+        <Dropdown.Popover className="md:hidden">
           <div className="px-3">
             <UserProfile />
           </div>

--- a/src/features/dashboard/components/mobile-nav.tsx
+++ b/src/features/dashboard/components/mobile-nav.tsx
@@ -2,6 +2,8 @@ import { PanelRightIcon } from "lucide-react";
 
 import { Button, Dropdown, Tooltip } from "@heroui/react";
 
+import { TOOLTIP_OFFSET } from "@/lib/constants";
+
 import { MobileNavMenu, UserProfile } from "@/features/dashboard";
 
 export default function MobileNav() {
@@ -12,7 +14,7 @@ export default function MobileNav() {
           <Button type="button" variant="ghost" size="sm" isIconOnly>
             <PanelRightIcon />
           </Button>
-          <Tooltip.Content showArrow>
+          <Tooltip.Content offset={TOOLTIP_OFFSET} showArrow>
             <Tooltip.Arrow />
             <p>Navigation</p>
           </Tooltip.Content>

--- a/src/features/dashboard/components/mobile-nav.tsx
+++ b/src/features/dashboard/components/mobile-nav.tsx
@@ -1,0 +1,23 @@
+import { PanelRightIcon } from "lucide-react";
+
+import { Button, Dropdown } from "@heroui/react";
+
+import { MobileNavMenu, UserProfile } from "@/features/dashboard";
+
+export default function MobileNav() {
+  return (
+    <nav>
+      <Dropdown>
+        <Button type="button" variant="ghost" size="sm" isIconOnly className="md:hidden">
+          <PanelRightIcon />
+        </Button>
+        <Dropdown.Popover>
+          <div className="px-3">
+            <UserProfile />
+          </div>
+          <MobileNavMenu />
+        </Dropdown.Popover>
+      </Dropdown>
+    </nav>
+  );
+}

--- a/src/features/dashboard/index.ts
+++ b/src/features/dashboard/index.ts
@@ -13,3 +13,7 @@ export { default as NavList } from "./components/nav-list";
 export { default as UserProfile } from "./components/user-profile";
 
 export { default as SignOutButton } from "./components/sign-out-button";
+
+export { default as MobileNav } from "./components/mobile-nav";
+
+export { default as MobileNavMenu } from "./components/mobile-nav-menu";

--- a/src/features/dashboard/lib/config.ts
+++ b/src/features/dashboard/lib/config.ts
@@ -17,3 +17,8 @@ export const navItems: NavItem[] = [
     href: PROFILE_PATH,
   },
 ];
+
+export const mobileNavItems: NavItem[] = navItems.map((navItem) => ({
+  ...navItem,
+  id: navItem.id.replace("sidebar", "mobile"),
+}));

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,3 +3,5 @@ export const APP_NAME = "DeviceMGR";
 export const APP_DESC = "A device management dashboard built with Next.js.";
 
 export const GITHUB_REPO = "https://github.com/starlightroad/devicemgr";
+
+export const TOOLTIP_OFFSET = 12;


### PR DESCRIPTION
This PR introduces the mobile nav.

## Changes
- Built the mobile navigation.
- Added a sign out button to allow users to sign out of the app.
- Created a `useSignOut` hook.
- Added a tooltip to the mobile nav button on hover.
- Set the role of the nav element to `Navigation`.
- Hid the popoever on medium screens.