### PR TITLE
Replace hard-coded tooltip offset value

### DIFF
--- a/src/components/theme-button.tsx
+++ b/src/components/theme-button.tsx
@@ -6,6 +6,8 @@ import { useTheme } from "@wrksz/themes/client";
 
 import { MoonIcon, SunIcon } from "lucide-react";
 
+import { TOOLTIP_OFFSET } from "@/lib/constants";
+
 export default function ThemeButton() {
   const { resolvedTheme, setTheme } = useTheme();
 
@@ -22,7 +24,7 @@ export default function ThemeButton() {
         <SunIcon className="h-4 w-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
         <MoonIcon className="absolute h-4 w-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0 dark:text-neutral-100" />
       </Button>
-      <Tooltip.Content offset={12} showArrow>
+      <Tooltip.Content offset={TOOLTIP_OFFSET} showArrow>
         <Tooltip.Arrow />
         <p>Toggle theme</p>
       </Tooltip.Content>


### PR DESCRIPTION
This PR updates the offset value of the tooltip from the theme button.

## Changes
- Replaced hard-coded value with `TOOLTIP_OFFSET` constant.