### PR TITLE
Feature/build stat cards

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { Card } from "@heroui/react";
 
 import { MobileNav } from "@/features/dashboard";
 
-import { InUseDevices, TotalDevices, TotalDevicesSkeleton } from "@/features/device";
+import { DeviceStatSkeleton, InUseDevices, TotalDevices } from "@/features/device";
 
 export default function DashboardPage() {
   return (
@@ -16,12 +16,12 @@ export default function DashboardPage() {
       <main className="flex flex-col gap-5">
         <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
           <article>
-            <Suspense fallback={<TotalDevicesSkeleton />}>
+            <Suspense fallback={<DeviceStatSkeleton />}>
               <TotalDevices />
             </Suspense>
           </article>
           <article>
-            <Suspense fallback={<TotalDevicesSkeleton />}>
+            <Suspense fallback={<DeviceStatSkeleton />}>
               <InUseDevices />
             </Suspense>
           </article>

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -14,7 +14,7 @@ export default function DashboardPage() {
         <MobileNav />
       </header>
       <main className="flex flex-col gap-5">
-        <div className="grid gap-5 sm:grid-cols-2">
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
           <article>
             <Suspense fallback={<TotalDevicesSkeleton />}>
               <TotalDevices />

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -4,7 +4,13 @@ import { Card } from "@heroui/react";
 
 import { MobileNav } from "@/features/dashboard";
 
-import { DeviceStatSkeleton, InUseDevices, StorageDevices, TotalDevices } from "@/features/device";
+import {
+  DecommissionedDevices,
+  DeviceStatSkeleton,
+  InUseDevices,
+  StorageDevices,
+  TotalDevices,
+} from "@/features/device";
 
 export default function DashboardPage() {
   return (
@@ -31,12 +37,9 @@ export default function DashboardPage() {
             </Suspense>
           </article>
           <article>
-            <Card>
-              <Card.Header>
-                <Card.Title>Health Status</Card.Title>
-                <Card.Description>Everything looks good.</Card.Description>
-              </Card.Header>
-            </Card>
+            <Suspense fallback={<DeviceStatSkeleton />}>
+              <DecommissionedDevices />
+            </Suspense>
           </article>
         </div>
         <article>

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { Card } from "@heroui/react";
 
 import { MobileNav } from "@/features/dashboard";
 
-import { DeviceStatSkeleton, InUseDevices, TotalDevices } from "@/features/device";
+import { DeviceStatSkeleton, InUseDevices, StorageDevices, TotalDevices } from "@/features/device";
 
 export default function DashboardPage() {
   return (
@@ -23,6 +23,11 @@ export default function DashboardPage() {
           <article>
             <Suspense fallback={<DeviceStatSkeleton />}>
               <InUseDevices />
+            </Suspense>
+          </article>
+          <article>
+            <Suspense fallback={<DeviceStatSkeleton />}>
+              <StorageDevices />
             </Suspense>
           </article>
           <article>

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { Card } from "@heroui/react";
 
 import { MobileNav } from "@/features/dashboard";
 
-import { TotalDevices, TotalDevicesSkeleton } from "@/features/device";
+import { InUseDevices, TotalDevices, TotalDevicesSkeleton } from "@/features/device";
 
 export default function DashboardPage() {
   return (
@@ -18,6 +18,11 @@ export default function DashboardPage() {
           <article>
             <Suspense fallback={<TotalDevicesSkeleton />}>
               <TotalDevices />
+            </Suspense>
+          </article>
+          <article>
+            <Suspense fallback={<TotalDevicesSkeleton />}>
+              <InUseDevices />
             </Suspense>
           </article>
           <article>

--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -28,7 +28,7 @@ export const getDevicesCount = async (): Promise<ActionResult<number>> => {
   }
 };
 
-export const getDevicesInUseCount = async (): Promise<ActionResult<number>> => {
+export const getDevicesCountByStatus = async (status: string): Promise<ActionResult<number>> => {
   try {
     const session = await getSession();
 
@@ -37,7 +37,7 @@ export const getDevicesInUseCount = async (): Promise<ActionResult<number>> => {
       .from(devicesTable)
       .leftJoin(usersTable, eq(devicesTable.userId, session.userId))
       .leftJoin(deviceStatusesTable, eq(devicesTable.statusId, deviceStatusesTable.id))
-      .where(ilike(deviceStatusesTable.name, "in use"));
+      .where(ilike(deviceStatusesTable.name, status));
 
     return {
       data: data[0].count,

--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -1,12 +1,12 @@
 "use server";
 
-import { count, eq } from "drizzle-orm";
+import { count, eq, ilike } from "drizzle-orm";
 
 import { db } from "@/db/client";
 
 import type { ActionResult } from "@/lib/definitions";
 
-import { devicesTable } from "@/db/schemas";
+import { devicesTable, deviceStatusesTable, usersTable } from "@/db/schemas";
 
 import { getSession } from "@/dal/session";
 
@@ -15,6 +15,29 @@ export const getDevicesCount = async (): Promise<ActionResult<number>> => {
     const session = await getSession();
 
     const data = await db.select({ count: count() }).from(devicesTable).where(eq(devicesTable.userId, session.userId));
+
+    return {
+      data: data[0].count,
+      error: null,
+    };
+  } catch {
+    return {
+      data: null,
+      error: "Failed to load data.",
+    };
+  }
+};
+
+export const getDevicesInUseCount = async (): Promise<ActionResult<number>> => {
+  try {
+    const session = await getSession();
+
+    const data = await db
+      .select({ count: count() })
+      .from(devicesTable)
+      .leftJoin(usersTable, eq(devicesTable.userId, session.userId))
+      .leftJoin(deviceStatusesTable, eq(devicesTable.statusId, deviceStatusesTable.id))
+      .where(ilike(deviceStatusesTable.name, "in use"));
 
     return {
       data: data[0].count,

--- a/src/features/device/components/decommissioned-devices.tsx
+++ b/src/features/device/components/decommissioned-devices.tsx
@@ -1,0 +1,25 @@
+import { Card } from "@heroui/react";
+
+import { HistoryIcon } from "lucide-react";
+
+import { getDevicesCountByStatus } from "@/dal/device";
+
+export default async function DecommissionedDevices() {
+  const { data, error } = await getDevicesCountByStatus("decommissioned");
+
+  return (
+    <Card>
+      <Card.Header className="flex-row items-center gap-2">
+        <HistoryIcon className="text-muted size-4" />
+        <Card.Title className="text-muted">Decommissioned</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        {error ? (
+          <p className="text-foreground mb-4 text-center text-base">{error}</p>
+        ) : (
+          <p className="text-foreground text-4xl font-semibold">{data}</p>
+        )}
+      </Card.Content>
+    </Card>
+  );
+}

--- a/src/features/device/components/device-stat-skeleton.tsx
+++ b/src/features/device/components/device-stat-skeleton.tsx
@@ -1,6 +1,6 @@
 import { Card, Skeleton } from "@heroui/react";
 
-export default function TotalDevicesSkeleton() {
+export default function DeviceStatSkeleton() {
   return (
     <Card>
       <Card.Header>

--- a/src/features/device/components/in-use-devices.tsx
+++ b/src/features/device/components/in-use-devices.tsx
@@ -1,0 +1,25 @@
+import { Card } from "@heroui/react";
+
+import { ZapIcon } from "lucide-react";
+
+import { getDevicesInUseCount } from "@/dal/device";
+
+export default async function InUseDevices() {
+  const { data, error } = await getDevicesInUseCount();
+
+  return (
+    <Card>
+      <Card.Header className="flex-row items-center gap-2">
+        <ZapIcon className="text-muted size-4" />
+        <Card.Title className="text-muted">In Use</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        {error ? (
+          <p className="text-foreground mb-4 text-center text-base">{error}</p>
+        ) : (
+          <p className="text-foreground text-4xl font-semibold">{data}</p>
+        )}
+      </Card.Content>
+    </Card>
+  );
+}

--- a/src/features/device/components/in-use-devices.tsx
+++ b/src/features/device/components/in-use-devices.tsx
@@ -2,10 +2,10 @@ import { Card } from "@heroui/react";
 
 import { ZapIcon } from "lucide-react";
 
-import { getDevicesInUseCount } from "@/dal/device";
+import { getDevicesCountByStatus } from "@/dal/device";
 
 export default async function InUseDevices() {
-  const { data, error } = await getDevicesInUseCount();
+  const { data, error } = await getDevicesCountByStatus("in use");
 
   return (
     <Card>

--- a/src/features/device/components/storage-devices.tsx
+++ b/src/features/device/components/storage-devices.tsx
@@ -1,0 +1,25 @@
+import { Card } from "@heroui/react";
+
+import { PackageIcon } from "lucide-react";
+
+import { getDevicesCountByStatus } from "@/dal/device";
+
+export default async function StorageDevices() {
+  const { data, error } = await getDevicesCountByStatus("storage");
+
+  return (
+    <Card>
+      <Card.Header className="flex-row items-center gap-2">
+        <PackageIcon className="text-muted size-4" />
+        <Card.Title className="text-muted">Storage</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        {error ? (
+          <p className="text-foreground mb-4 text-center text-base">{error}</p>
+        ) : (
+          <p className="text-foreground text-4xl font-semibold">{data}</p>
+        )}
+      </Card.Content>
+    </Card>
+  );
+}

--- a/src/features/device/components/total-devices-skeleton.tsx
+++ b/src/features/device/components/total-devices-skeleton.tsx
@@ -2,14 +2,14 @@ import { Card, Skeleton } from "@heroui/react";
 
 export default function TotalDevicesSkeleton() {
   return (
-    <Card className="h-auto min-h-60">
+    <Card>
       <Card.Header>
         <Card.Title>
           <Skeleton className="h-6 w-24 rounded-lg" />
         </Card.Title>
       </Card.Header>
-      <Card.Content className="items-center justify-center">
-        <Skeleton className="mb-10 h-14 w-32 rounded" />
+      <Card.Content>
+        <Skeleton className="h-10 w-32 rounded" />
       </Card.Content>
     </Card>
   );

--- a/src/features/device/components/total-devices.tsx
+++ b/src/features/device/components/total-devices.tsx
@@ -1,20 +1,23 @@
 import { Card } from "@heroui/react";
 
+import { CpuIcon } from "lucide-react";
+
 import { getDevicesCount } from "@/dal/device";
 
 export default async function TotalDevices() {
   const { data: devicesCount, error } = await getDevicesCount();
 
   return (
-    <Card className="h-auto min-h-60">
-      <Card.Header>
-        <Card.Title>Total Devices</Card.Title>
+    <Card>
+      <Card.Header className="flex-row items-center gap-2">
+        <CpuIcon className="text-muted size-4" />
+        <Card.Title className="text-muted">Total Devices</Card.Title>
       </Card.Header>
-      <Card.Content className="items-center justify-center">
+      <Card.Content>
         {error ? (
-          <p className="text-muted mb-10 text-center text-base">{error}</p>
+          <p className="text-foreground mb-4 text-center text-base">{error}</p>
         ) : (
-          <p className="text-muted mb-10 text-6xl font-semibold">{devicesCount}</p>
+          <p className="text-foreground text-4xl font-semibold">{devicesCount}</p>
         )}
       </Card.Content>
     </Card>

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -5,3 +5,5 @@ export { default as DeviceStatSkeleton } from "./components/device-stat-skeleton
 export { default as InUseDevices } from "./components/in-use-devices";
 
 export { default as StorageDevices } from "./components/storage-devices";
+
+export { default as DecommissionedDevices } from "./components/decommissioned-devices";

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -1,3 +1,5 @@
 export { default as TotalDevices } from "./components/total-devices";
 
 export { default as TotalDevicesSkeleton } from "./components/total-devices-skeleton";
+
+export { default as InUseDevices } from "./components/in-use-devices";

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -1,5 +1,5 @@
 export { default as TotalDevices } from "./components/total-devices";
 
-export { default as TotalDevicesSkeleton } from "./components/total-devices-skeleton";
+export { default as DeviceStatSkeleton } from "./components/device-stat-skeleton";
 
 export { default as InUseDevices } from "./components/in-use-devices";

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -3,3 +3,5 @@ export { default as TotalDevices } from "./components/total-devices";
 export { default as DeviceStatSkeleton } from "./components/device-stat-skeleton";
 
 export { default as InUseDevices } from "./components/in-use-devices";
+
+export { default as StorageDevices } from "./components/storage-devices";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,1 +1,3 @@
 export const generateId = () => crypto.randomUUID().replaceAll("-", "");
+
+export const sleep = (ms = 1500) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
This PR builds the stat cards used via the dashboard page.

## Changes
- Refactored the total devices card.
- Created a function that gets the total number of records found by status.
- Built the card that shows the user's total number of devices in use.
- Built the card that shows the user's total number of devices in storage.
- Built the card that shows the user's total number of decommissioned devices.
- Refactored the loading UI skeleton so that it can be reusable across the stat cards.
- Created a sleep function to test out the loading state for each stat card.