### PR TITLE
Create function to check session from home page

### DIFF
--- a/src/components/cta.tsx
+++ b/src/components/cta.tsx
@@ -2,10 +2,10 @@ import Link from "next/link";
 
 import { buttonVariants } from "@heroui/react";
 
-import { getSession } from "@/dal/session";
+import { getSessionFromHomePage } from "@/dal/session";
 
 export async function CTA() {
-  const session = await getSession();
+  const session = await getSessionFromHomePage();
   const isUserLoggedIn = Boolean(session.userId);
 
   return (

--- a/src/dal/session.ts
+++ b/src/dal/session.ts
@@ -19,3 +19,13 @@ export const getSession = async () => {
     userId: data.session.userId,
   };
 };
+
+export const getSessionFromHomePage = async () => {
+  const data = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  return {
+    userId: data?.session.userId,
+  };
+};


### PR DESCRIPTION
This PR fixes #29.

## Changes
- Created the function `getSessionFromHomePage`. It checks the session on the home page. This is required for the CTA to prevent visitors on the home page from being redirected to the login page.