### PR TITLE
Feature/replace type status and group fields

### DIFF
--- a/src/dal/status.ts
+++ b/src/dal/status.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db/client";
+
+import type { ActionResult } from "@/lib/definitions";
+
+import { deviceStatusesTable, usersTable } from "@/db/schemas";
+
+import { getSession } from "@/dal/session";
+
+export const getDeviceStatuses = async (): Promise<ActionResult<Array<{ id: string; name: string }>>> => {
+  try {
+    const session = await getSession();
+
+    const data = await db
+      .select({
+        id: deviceStatusesTable.id,
+        name: deviceStatusesTable.name,
+      })
+      .from(deviceStatusesTable)
+      .innerJoin(usersTable, eq(deviceStatusesTable.userId, session.userId));
+
+    return {
+      data,
+      error: null,
+    };
+  } catch {
+    return {
+      data: null,
+      error: "Failed to load data.",
+    };
+  }
+};

--- a/src/dal/type.ts
+++ b/src/dal/type.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db/client";
+
+import type { ActionResult } from "@/lib/definitions";
+
+import { deviceTypesTable, usersTable } from "@/db/schemas";
+
+import { getSession } from "@/dal/session";
+
+export const getDeviceTypes = async (): Promise<ActionResult<Array<{ id: string; name: string }>>> => {
+  try {
+    const session = await getSession();
+
+    const data = await db
+      .select({
+        id: deviceTypesTable.id,
+        name: deviceTypesTable.name,
+      })
+      .from(deviceTypesTable)
+      .innerJoin(usersTable, eq(deviceTypesTable.userId, session.userId));
+
+    return {
+      data,
+      error: null,
+    };
+  } catch {
+    return {
+      data: null,
+      error: "Failed to load data.",
+    };
+  }
+};

--- a/src/dal/type.ts
+++ b/src/dal/type.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 
 import { db } from "@/db/client";
 
@@ -20,7 +20,8 @@ export const getDeviceTypes = async (): Promise<ActionResult<Array<{ id: string;
         name: deviceTypesTable.name,
       })
       .from(deviceTypesTable)
-      .innerJoin(usersTable, eq(deviceTypesTable.userId, session.userId));
+      .innerJoin(usersTable, eq(deviceTypesTable.userId, session.userId))
+      .orderBy(asc(deviceTypesTable.name));
 
     return {
       data,

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -92,6 +92,7 @@ export default function DeviceActions({ data }: { data: Device }) {
           onOpenChange={() => {
             setModalState(initialState);
           }}
+          data={data}
         />
       )}
       {modalState.isMoveAction && (

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -14,7 +14,7 @@ import {
   Trash2Icon,
 } from "lucide-react";
 
-import { EditDeviceModal, MoveDeviceModal } from "@/features/device";
+import { type Device, EditDeviceModal, MoveDeviceModal } from "@/features/device";
 
 const initialState = {
   isEditAction: false,
@@ -23,7 +23,7 @@ const initialState = {
   isDeleteAction: false,
 };
 
-export default function DeviceActions({ data }: { data: { deviceId: string; group: string } }) {
+export default function DeviceActions({ data }: { data: Device }) {
   const [modalState, setModalState] = useState<typeof initialState>(initialState);
 
   const openModal = (key: keyof typeof initialState) => {

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -64,8 +64,8 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                   >
                     <Label>Type</Label>
                     <Select.Trigger className="h-10">
-                      <Select.Value />
-                      <Select.Indicator className="leading-6" />
+                      <Select.Value className="leading-6" />
+                      <Select.Indicator />
                     </Select.Trigger>
                     <Select.Popover>
                       <ListBox>
@@ -92,8 +92,8 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                   >
                     <Label>Status</Label>
                     <Select.Trigger className="h-10">
-                      <Select.Value />
-                      <Select.Indicator className="leading-6" />
+                      <Select.Value className="leading-6" />
+                      <Select.Indicator />
                     </Select.Trigger>
                     <Select.Popover>
                       <ListBox>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { useState } from "react";
+
 import { FolderClosedIcon } from "lucide-react";
 
-import { type ChangeEvent, useState } from "react";
-
-import { Button, Form, Input, Key, Label, ListBox, Modal, Select, Surface, TextField } from "@heroui/react";
+import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField } from "@heroui/react";
 
 import { generateId, useDeviceStatuses, type MoveDeviceModalProps } from "@/features/device";
 
@@ -21,14 +21,8 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
 
   const { statuses } = useDeviceStatuses();
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-
+  const handleChange = (name: string, value: string) => {
     setFormData((prevState) => ({ ...prevState, [name]: value }));
-  };
-
-  const handleSelectChange = (name: string, value: Key | null) => {
-    setFormData((prevState) => ({ ...prevState, [name]: String(value) }));
   };
 
   return (
@@ -55,7 +49,7 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                       autoComplete="off"
                       className="h-10"
                       value={formData.name}
-                      onChange={handleChange}
+                      onChange={(e) => handleChange(e.target.name, e.target.value)}
                     />
                   </TextField>
                   <TextField type="text" name="type" isRequired>
@@ -66,7 +60,7 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                       autoComplete="off"
                       className="h-10"
                       value={formData.type}
-                      onChange={handleChange}
+                      onChange={(e) => handleChange(e.target.name, e.target.value)}
                     />
                   </TextField>
                   <Select
@@ -75,7 +69,7 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                     placeholder="Select status"
                     isRequired
                     value={formData.status}
-                    onChange={(e) => handleSelectChange("status", e)}
+                    onChange={(e) => handleChange("status", String(e))}
                   >
                     <Label>Status</Label>
                     <Select.Trigger className="h-10">
@@ -105,7 +99,7 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                       autoComplete="off"
                       className="h-10"
                       value={formData.group}
-                      onChange={handleChange}
+                      onChange={(e) => handleChange(e.target.name, e.target.value)}
                     />
                   </TextField>
                   <TextField type="text" name="serial-number" isRequired>
@@ -116,7 +110,7 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                       autoComplete="off"
                       className="h-10"
                       value={formData["serial-number"]}
-                      onChange={handleChange}
+                      onChange={(e) => handleChange(e.target.name, e.target.value)}
                     />
                   </TextField>
                   <TextField type="text" name="ip-address">
@@ -127,7 +121,7 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                       autoComplete="off"
                       className="h-10"
                       value={formData["ip-address"]}
-                      onChange={handleChange}
+                      onChange={(e) => handleChange(e.target.name, e.target.value)}
                     />
                   </TextField>
                 </Form>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -6,7 +6,7 @@ import { FolderClosedIcon } from "lucide-react";
 
 import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField } from "@heroui/react";
 
-import { generateId, useDeviceStatuses, type MoveDeviceModalProps } from "@/features/device";
+import { generateId, useDeviceStatuses, useDeviceTypes, type MoveDeviceModalProps } from "@/features/device";
 
 export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDeviceModalProps) {
   const [formData, setFormData] = useState({
@@ -14,10 +14,12 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
     name: data.name,
     "serial-number": data.serialNumber,
     "ip-address": data.ipAddress ?? "",
-    type: data.type,
+    type: generateId(data.type),
     status: generateId(data.status),
     group: data.group,
   });
+
+  const { types } = useDeviceTypes();
 
   const { statuses } = useDeviceStatuses();
 
@@ -52,17 +54,34 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                       onChange={(e) => handleChange(e.target.name, e.target.value)}
                     />
                   </TextField>
-                  <TextField type="text" name="type" isRequired>
+                  <Select
+                    name="type"
+                    variant="secondary"
+                    placeholder="Select type"
+                    isRequired
+                    value={formData.type}
+                    onChange={(e) => handleChange("type", String(e))}
+                  >
                     <Label>Type</Label>
-                    <Input
-                      variant="secondary"
-                      placeholder="Select type"
-                      autoComplete="off"
-                      className="h-10"
-                      value={formData.type}
-                      onChange={(e) => handleChange(e.target.name, e.target.value)}
-                    />
-                  </TextField>
+                    <Select.Trigger className="h-10">
+                      <Select.Value />
+                      <Select.Indicator className="leading-6" />
+                    </Select.Trigger>
+                    <Select.Popover>
+                      <ListBox>
+                        {types?.map((type) => {
+                          const id = generateId(type.name);
+
+                          return (
+                            <ListBox.Item key={id} id={id} textValue={type.name}>
+                              {type.name}
+                              <ListBox.ItemIndicator />
+                            </ListBox.Item>
+                          );
+                        })}
+                      </ListBox>
+                    </Select.Popover>
+                  </Select>
                   <Select
                     name="status"
                     variant="secondary"

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -4,9 +4,9 @@ import { FolderClosedIcon } from "lucide-react";
 
 import { type ChangeEvent, useState } from "react";
 
-import { Button, Form, Input, Label, Modal, Surface, TextField } from "@heroui/react";
+import { Button, Form, Input, Key, Label, ListBox, Modal, Select, Surface, TextField } from "@heroui/react";
 
-import type { MoveDeviceModalProps } from "@/features/device";
+import { generateId, useDeviceStatuses, type MoveDeviceModalProps } from "@/features/device";
 
 export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDeviceModalProps) {
   const [formData, setFormData] = useState({
@@ -15,14 +15,20 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
     "serial-number": data.serialNumber,
     "ip-address": data.ipAddress ?? "",
     type: data.type,
-    status: data.status,
+    status: generateId(data.status),
     group: data.group,
   });
+
+  const { statuses } = useDeviceStatuses();
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
 
     setFormData((prevState) => ({ ...prevState, [name]: value }));
+  };
+
+  const handleSelectChange = (name: string, value: Key | null) => {
+    setFormData((prevState) => ({ ...prevState, [name]: String(value) }));
   };
 
   return (
@@ -63,17 +69,34 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                       onChange={handleChange}
                     />
                   </TextField>
-                  <TextField type="text" name="status" isRequired>
+                  <Select
+                    name="status"
+                    variant="secondary"
+                    placeholder="Select status"
+                    isRequired
+                    value={formData.status}
+                    onChange={(e) => handleSelectChange("status", e)}
+                  >
                     <Label>Status</Label>
-                    <Input
-                      variant="secondary"
-                      placeholder="Select status"
-                      autoComplete="off"
-                      className="h-10"
-                      value={formData.status}
-                      onChange={handleChange}
-                    />
-                  </TextField>
+                    <Select.Trigger className="h-10">
+                      <Select.Value />
+                      <Select.Indicator className="leading-6" />
+                    </Select.Trigger>
+                    <Select.Popover>
+                      <ListBox>
+                        {statuses?.map((status) => {
+                          const id = generateId(status.name);
+
+                          return (
+                            <ListBox.Item key={id} id={id} textValue={status.name}>
+                              {status.name}
+                              <ListBox.ItemIndicator />
+                            </ListBox.Item>
+                          );
+                        })}
+                      </ListBox>
+                    </Select.Popover>
+                  </Select>
                   <TextField type="text" name="group" isRequired>
                     <Label>Group</Label>
                     <Input

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -6,7 +6,13 @@ import { FolderClosedIcon } from "lucide-react";
 
 import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField } from "@heroui/react";
 
-import { generateId, useDeviceStatuses, useDeviceTypes, type MoveDeviceModalProps } from "@/features/device";
+import {
+  generateId,
+  useDeviceGroups,
+  useDeviceStatuses,
+  useDeviceTypes,
+  type MoveDeviceModalProps,
+} from "@/features/device";
 
 export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDeviceModalProps) {
   const [formData, setFormData] = useState({
@@ -16,12 +22,14 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
     "ip-address": data.ipAddress ?? "",
     type: generateId(data.type),
     status: generateId(data.status),
-    group: data.group,
+    group: generateId(data.group),
   });
 
   const { types } = useDeviceTypes();
 
   const { statuses } = useDeviceStatuses();
+
+  const { groups } = useDeviceGroups();
 
   const handleChange = (name: string, value: string) => {
     setFormData((prevState) => ({ ...prevState, [name]: value }));
@@ -110,17 +118,34 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                       </ListBox>
                     </Select.Popover>
                   </Select>
-                  <TextField type="text" name="group" isRequired>
+                  <Select
+                    name="group"
+                    variant="secondary"
+                    placeholder="Select group"
+                    isRequired
+                    value={formData.group}
+                    onChange={(e) => handleChange("group", String(e))}
+                  >
                     <Label>Group</Label>
-                    <Input
-                      variant="secondary"
-                      placeholder="Select group"
-                      autoComplete="off"
-                      className="h-10"
-                      value={formData.group}
-                      onChange={(e) => handleChange(e.target.name, e.target.value)}
-                    />
-                  </TextField>
+                    <Select.Trigger className="h-10">
+                      <Select.Value className="leading-6" />
+                      <Select.Indicator />
+                    </Select.Trigger>
+                    <Select.Popover>
+                      <ListBox>
+                        {groups?.map((group) => {
+                          const id = generateId(group.name);
+
+                          return (
+                            <ListBox.Item key={id} id={id} textValue={group.name}>
+                              {group.name}
+                              <ListBox.ItemIndicator />
+                            </ListBox.Item>
+                          );
+                        })}
+                      </ListBox>
+                    </Select.Popover>
+                  </Select>
                   <TextField type="text" name="serial-number" isRequired>
                     <Label>Serial Number</Label>
                     <Input

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -2,9 +2,29 @@
 
 import { FolderClosedIcon } from "lucide-react";
 
-import { Button, Form, Input, Label, Modal, type ModalRootProps, Surface, TextField } from "@heroui/react";
+import { type ChangeEvent, useState } from "react";
 
-export default function EditDeviceModal({ isOpen, onOpenChange }: Pick<ModalRootProps, "isOpen" | "onOpenChange">) {
+import { Button, Form, Input, Label, Modal, Surface, TextField } from "@heroui/react";
+
+import type { MoveDeviceModalProps } from "@/features/device";
+
+export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDeviceModalProps) {
+  const [formData, setFormData] = useState({
+    id: data.id,
+    name: data.name,
+    "serial-number": data.serialNumber,
+    "ip-address": data.ipAddress ?? "",
+    type: data.type,
+    status: data.status,
+    group: data.group,
+  });
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    setFormData((prevState) => ({ ...prevState, [name]: value }));
+  };
+
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
       <Button className="hidden">Edit Device</Button>
@@ -23,27 +43,69 @@ export default function EditDeviceModal({ isOpen, onOpenChange }: Pick<ModalRoot
                 <Form id="edit-device-form" onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-4">
                   <TextField type="text" name="name" isRequired>
                     <Label>Name</Label>
-                    <Input variant="secondary" placeholder="John's MacBook Pro" autoComplete="off" className="h-10" />
+                    <Input
+                      variant="secondary"
+                      placeholder="John's MacBook Pro"
+                      autoComplete="off"
+                      className="h-10"
+                      value={formData.name}
+                      onChange={handleChange}
+                    />
                   </TextField>
                   <TextField type="text" name="type" isRequired>
                     <Label>Type</Label>
-                    <Input variant="secondary" placeholder="Select type" autoComplete="off" className="h-10" />
+                    <Input
+                      variant="secondary"
+                      placeholder="Select type"
+                      autoComplete="off"
+                      className="h-10"
+                      value={formData.type}
+                      onChange={handleChange}
+                    />
                   </TextField>
                   <TextField type="text" name="status" isRequired>
                     <Label>Status</Label>
-                    <Input variant="secondary" placeholder="Select status" autoComplete="off" className="h-10" />
+                    <Input
+                      variant="secondary"
+                      placeholder="Select status"
+                      autoComplete="off"
+                      className="h-10"
+                      value={formData.status}
+                      onChange={handleChange}
+                    />
                   </TextField>
                   <TextField type="text" name="group" isRequired>
                     <Label>Group</Label>
-                    <Input variant="secondary" placeholder="Select group" autoComplete="off" className="h-10" />
+                    <Input
+                      variant="secondary"
+                      placeholder="Select group"
+                      autoComplete="off"
+                      className="h-10"
+                      value={formData.group}
+                      onChange={handleChange}
+                    />
                   </TextField>
                   <TextField type="text" name="serial-number" isRequired>
                     <Label>Serial Number</Label>
-                    <Input variant="secondary" placeholder="SN-LTP-1002" autoComplete="off" className="h-10" />
+                    <Input
+                      variant="secondary"
+                      placeholder="SN-LTP-1002"
+                      autoComplete="off"
+                      className="h-10"
+                      value={formData["serial-number"]}
+                      onChange={handleChange}
+                    />
                   </TextField>
                   <TextField type="text" name="ip-address">
                     <Label>IP Address</Label>
-                    <Input variant="secondary" placeholder="192.168.1.1" autoComplete="off" className="h-10" />
+                    <Input
+                      variant="secondary"
+                      placeholder="192.168.1.1"
+                      autoComplete="off"
+                      className="h-10"
+                      value={formData["ip-address"]}
+                      onChange={handleChange}
+                    />
                   </TextField>
                 </Form>
               </Surface>

--- a/src/features/device/components/recent-devices.tsx
+++ b/src/features/device/components/recent-devices.tsx
@@ -73,12 +73,7 @@ export default async function RecentDevices() {
                       <Table.Cell>{device.group}</Table.Cell>
                       <Table.Cell>{device.serialNumber}</Table.Cell>
                       <Table.Cell>
-                        <DeviceActions
-                          data={{
-                            deviceId: device.id,
-                            group: device.group,
-                          }}
-                        />
+                        <DeviceActions data={device} />
                       </Table.Cell>
                     </Table.Row>
                   );

--- a/src/features/device/hooks/use-statuses.tsx
+++ b/src/features/device/hooks/use-statuses.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getDeviceStatuses } from "@/dal/status";
+
+export default function useDeviceStatuses() {
+  const [statuses, setStatuses] = useState<{ id: string; name: string }[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchStatuses = async () => {
+      try {
+        const response = await getDeviceStatuses();
+
+        setStatuses(response.data);
+      } catch {
+        setError("Failed to get statuses.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStatuses();
+  }, []);
+
+  return { statuses, loading, error };
+}

--- a/src/features/device/hooks/use-types.tsx
+++ b/src/features/device/hooks/use-types.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getDeviceTypes } from "@/dal/type";
+
+export default function useDeviceTypes() {
+  const [types, setTypes] = useState<{ id: string; name: string }[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchTypes = async () => {
+      try {
+        const response = await getDeviceTypes();
+
+        setTypes(response.data);
+      } catch {
+        setError("Failed to get groups.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTypes();
+  }, []);
+
+  return { types, loading, error };
+}

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -8,6 +8,8 @@ export { default as useDeviceGroups } from "./hooks/use-groups";
 
 export { default as useDeviceStatuses } from "./hooks/use-statuses";
 
+export { default as useDeviceTypes } from "./hooks/use-types";
+
 export { default as TotalDevices } from "./components/total-devices";
 
 export { default as DeviceStatSkeleton } from "./components/device-stat-skeleton";

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -6,6 +6,8 @@ export * from "./lib/utils";
 
 export { default as useDeviceGroups } from "./hooks/use-groups";
 
+export { default as useDeviceStatuses } from "./hooks/use-statuses";
+
 export { default as TotalDevices } from "./components/total-devices";
 
 export { default as DeviceStatSkeleton } from "./components/device-stat-skeleton";

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -9,5 +9,5 @@ export type Device = Pick<typeof devicesTable.$inferSelect, "id" | "name" | "ser
 };
 
 export type MoveDeviceModalProps = Pick<ModalRootProps, "isOpen" | "onOpenChange"> & {
-  data: { deviceId: string; group: string };
+  data: Device;
 };


### PR DESCRIPTION
This PR updates several form fields.

## Changes
- Updated the type form field to allow users to select from a list of options.
- Updated the status form field to allow users to select from a list of options.
- Updated the group form field to allow users to select from a list of options.
- Created the hook `useDeviceStatuses` to fetch the statuses on the client.
- Created the hook `useDeviceTypes` to fetch the types on the client.