### PR TITLE
Refactor the edit and move modals

### DIFF
--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button, Dropdown, type Key, Label, Separator } from "@heroui/react";
 
@@ -16,37 +16,15 @@ import {
 
 import { type Device, EditDeviceModal, MoveDeviceModal } from "@/features/device";
 
-const initialState = {
-  isEditAction: false,
-  isMoveAction: false,
-  isShareAction: false,
-  isDeleteAction: false,
-};
+export default function DeviceActions({ device }: { device: Device }) {
+  const [modal, setModal] = useState<Key | null>(null);
 
-export default function DeviceActions({ data }: { data: Device }) {
-  const [modalState, setModalState] = useState<typeof initialState>(initialState);
-
-  const openModal = (key: keyof typeof initialState) => {
-    setModalState((prevState) => ({ ...prevState, [key]: true }));
-  };
-
-  const handleAction = (key: Key) => {
-    if (key === "view") {
+  useEffect(() => {
+    if (modal === "view") {
       // Will need to change the URL in the future.
       window.open("#", "_blank");
-      return;
     }
-
-    if (key === "edit") {
-      openModal("isEditAction");
-      return;
-    }
-
-    if (key === "move") {
-      openModal("isMoveAction");
-      return;
-    }
-  };
+  }, [modal]);
 
   return (
     <>
@@ -55,7 +33,7 @@ export default function DeviceActions({ data }: { data: Device }) {
           <MoreVerticalIcon />
         </Button>
         <Dropdown.Popover placement="bottom right">
-          <Dropdown.Menu onAction={(key) => handleAction(key)}>
+          <Dropdown.Menu onAction={(key) => setModal(key)}>
             <Dropdown.Item id="view" textValue="View">
               <SquareArrowUpRightIcon className="text-muted size-4" />
               <Label>View</Label>
@@ -86,24 +64,10 @@ export default function DeviceActions({ data }: { data: Device }) {
           </Dropdown.Menu>
         </Dropdown.Popover>
       </Dropdown>
-      {modalState.isEditAction && (
-        <EditDeviceModal
-          isOpen={modalState.isEditAction}
-          onOpenChange={() => {
-            setModalState(initialState);
-          }}
-          data={data}
-        />
-      )}
-      {modalState.isMoveAction && (
-        <MoveDeviceModal
-          isOpen={modalState.isMoveAction}
-          onOpenChange={() => {
-            setModalState(initialState);
-          }}
-          data={data}
-        />
-      )}
+
+      {modal === "edit" && <EditDeviceModal device={device} onClose={() => setModal(null)} />}
+
+      {modal === "move" && <MoveDeviceModal deviceGroup={device.group} onClose={() => setModal(null)} />}
     </>
   );
 }

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -7,36 +7,39 @@ import { FolderClosedIcon } from "lucide-react";
 import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField } from "@heroui/react";
 
 import {
+  type Device,
+  type EditDeviceModalProps,
   generateId,
   useDeviceGroups,
   useDeviceStatuses,
   useDeviceTypes,
-  type MoveDeviceModalProps,
 } from "@/features/device";
 
-export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDeviceModalProps) {
-  const [formData, setFormData] = useState({
-    id: data.id,
-    name: data.name,
-    "serial-number": data.serialNumber,
-    "ip-address": data.ipAddress ?? "",
-    type: generateId(data.type),
-    status: generateId(data.status),
-    group: generateId(data.group),
-  });
+const generateFieldIds = (device: Device) => ({
+  id: { name: "id", value: device.id },
+  name: { name: "name", value: device.name },
+  serialNumber: { name: "serial-number", value: device.serialNumber },
+  ipAddress: { name: "ip-address", value: device.ipAddress ?? "" },
+  type: { name: "type", value: generateId(device.type) },
+  status: { name: "status", value: generateId(device.status) },
+  group: { name: "group", value: generateId(device.group) },
+});
 
+export default function EditDeviceModal({ device, onClose }: EditDeviceModalProps) {
   const { types } = useDeviceTypes();
 
   const { statuses } = useDeviceStatuses();
 
   const { groups } = useDeviceGroups();
 
-  const handleChange = (name: string, value: string) => {
-    setFormData((prevState) => ({ ...prevState, [name]: value }));
+  const [field, setField] = useState(generateFieldIds(device));
+
+  const handleFieldChange = (name: keyof typeof field, value: string) => {
+    setField((prevState) => ({ ...prevState, [name]: { name: prevState[name].name, value } }));
   };
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+    <Modal isOpen onOpenChange={onClose}>
       <Button className="hidden">Edit Device</Button>
       <Modal.Backdrop>
         <Modal.Container placement="auto">
@@ -51,24 +54,24 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
             <Modal.Body className="px-1 py-4">
               <Surface variant="default">
                 <Form id="edit-device-form" onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-4">
-                  <TextField type="text" name="name" isRequired>
+                  <TextField type="text" name={field.name.name} isRequired>
                     <Label>Name</Label>
                     <Input
                       variant="secondary"
                       placeholder="John's MacBook Pro"
                       autoComplete="off"
                       className="h-10"
-                      value={formData.name}
-                      onChange={(e) => handleChange(e.target.name, e.target.value)}
+                      value={field.name.value}
+                      onChange={(e) => handleFieldChange("name", e.target.value)}
                     />
                   </TextField>
                   <Select
-                    name="type"
+                    name={field.type.name}
                     variant="secondary"
                     placeholder="Select type"
                     isRequired
-                    value={formData.type}
-                    onChange={(e) => handleChange("type", String(e))}
+                    value={field.type.value}
+                    onChange={(e) => handleFieldChange("type", String(e))}
                   >
                     <Label>Type</Label>
                     <Select.Trigger className="h-10">
@@ -91,12 +94,12 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                     </Select.Popover>
                   </Select>
                   <Select
-                    name="status"
+                    name={field.status.name}
                     variant="secondary"
                     placeholder="Select status"
                     isRequired
-                    value={formData.status}
-                    onChange={(e) => handleChange("status", String(e))}
+                    value={field.status.value}
+                    onChange={(e) => handleFieldChange("status", String(e))}
                   >
                     <Label>Status</Label>
                     <Select.Trigger className="h-10">
@@ -119,12 +122,12 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                     </Select.Popover>
                   </Select>
                   <Select
-                    name="group"
+                    name={field.group.name}
                     variant="secondary"
                     placeholder="Select group"
                     isRequired
-                    value={formData.group}
-                    onChange={(e) => handleChange("group", String(e))}
+                    value={field.group.value}
+                    onChange={(e) => handleFieldChange("group", String(e))}
                   >
                     <Label>Group</Label>
                     <Select.Trigger className="h-10">
@@ -146,26 +149,26 @@ export default function EditDeviceModal({ isOpen, onOpenChange, data }: MoveDevi
                       </ListBox>
                     </Select.Popover>
                   </Select>
-                  <TextField type="text" name="serial-number" isRequired>
+                  <TextField type="text" name={field.serialNumber.name} isRequired>
                     <Label>Serial Number</Label>
                     <Input
                       variant="secondary"
                       placeholder="SN-LTP-1002"
                       autoComplete="off"
                       className="h-10"
-                      value={formData["serial-number"]}
-                      onChange={(e) => handleChange(e.target.name, e.target.value)}
+                      value={field.serialNumber.value}
+                      onChange={(e) => handleFieldChange("serialNumber", e.target.value)}
                     />
                   </TextField>
-                  <TextField type="text" name="ip-address">
+                  <TextField type="text" name={field.ipAddress.name}>
                     <Label>IP Address</Label>
                     <Input
                       variant="secondary"
                       placeholder="192.168.1.1"
                       autoComplete="off"
                       className="h-10"
-                      value={formData["ip-address"]}
-                      onChange={(e) => handleChange(e.target.name, e.target.value)}
+                      value={field.ipAddress.value}
+                      onChange={(e) => handleFieldChange("ipAddress", e.target.value)}
                     />
                   </TextField>
                 </Form>

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -4,17 +4,17 @@ import { useState } from "react";
 
 import { FolderClosedIcon } from "lucide-react";
 
-import { Button, Form, Key, Label, ListBox, Modal, Select, Surface } from "@heroui/react";
+import { Button, Form, type Key, Label, ListBox, Modal, Select, Surface } from "@heroui/react";
 
 import { generateId, type MoveDeviceModalProps, useDeviceGroups } from "@/features/device";
 
-export default function MoveDeviceModal({ isOpen, onOpenChange, data }: MoveDeviceModalProps) {
+export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModalProps) {
   const { groups } = useDeviceGroups();
 
-  const [selectedGroup, setSelectedGroup] = useState<Key | null>(generateId(data.group));
+  const [selectedGroup, setSelectedGroup] = useState<Key | null>(generateId(deviceGroup));
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+    <Modal isOpen onOpenChange={onClose}>
       <Button className="hidden">Move Device</Button>
       <Modal.Backdrop>
         <Modal.Container placement="auto">

--- a/src/features/device/components/recent-devices.tsx
+++ b/src/features/device/components/recent-devices.tsx
@@ -73,7 +73,7 @@ export default async function RecentDevices() {
                       <Table.Cell>{device.group}</Table.Cell>
                       <Table.Cell>{device.serialNumber}</Table.Cell>
                       <Table.Cell>
-                        <DeviceActions data={device} />
+                        <DeviceActions device={device} />
                       </Table.Cell>
                     </Table.Row>
                   );

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -1,5 +1,3 @@
-import type { ModalRootProps } from "@heroui/react";
-
 import { devicesTable } from "@/db/schemas";
 
 export type Device = Pick<typeof devicesTable.$inferSelect, "id" | "name" | "serialNumber" | "ipAddress"> & {
@@ -8,6 +6,6 @@ export type Device = Pick<typeof devicesTable.$inferSelect, "id" | "name" | "ser
   group: string;
 };
 
-export type MoveDeviceModalProps = Pick<ModalRootProps, "isOpen" | "onOpenChange"> & {
-  data: Device;
-};
+export type EditDeviceModalProps = { device: Device; onClose: () => void };
+
+export type MoveDeviceModalProps = { deviceGroup: string; onClose: () => void };


### PR DESCRIPTION
This PR refactors the edit and move modals.

## Changes
- Changed the modal state to use a single key from a selected action.
- Added a `useEffect` that will open a new tab if the modal value is `view`.
- Updated the state of the fields for better management.
- Updated the logic that mounts the modals based on the modal value.
- Modals now use `onClose` function which sets the modal state to `null`.
- `<MoveDeviceModal />` now only requires the device group via the prop `deviceGroup`.