### PR TITLE
Feature/edit device action

### DIFF
--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -25,6 +25,8 @@ const generateFieldIds = (device: Device) => ({
   group: { name: "group", value: generateId(device.group) },
 });
 
+const FORM_ID = "edit-device-form";
+
 export default function EditDeviceModal({ device, onClose }: EditDeviceModalProps) {
   const { types } = useDeviceTypes();
 
@@ -53,7 +55,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
             </Modal.Header>
             <Modal.Body className="px-1 py-4">
               <Surface variant="default">
-                <Form id="edit-device-form" onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-4">
+                <Form id={FORM_ID} onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-4">
                   <TextField type="text" name={field.name.name} isRequired>
                     <Label>Name</Label>
                     <Input
@@ -178,7 +180,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
               <Button type="button" slot="close" variant="secondary">
                 Cancel
               </Button>
-              <Button type="submit" isDisabled>
+              <Button type="submit" form={FORM_ID} isDisabled>
                 Save
               </Button>
             </Modal.Footer>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -34,7 +34,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
 
   const [field, setField] = useState(generateDeviceFieldIds(device));
 
-  const [state, formAction, isFormLoading] = useActionState(updateDevice, undefined);
+  const [state, formAction, isFormLoading] = useActionState(updateDevice.bind(null, device.id), undefined);
 
   const handleFieldChange = useCallback((name: keyof typeof field, value: string) => {
     setField((prevState) => ({ ...prevState, [name]: { name: prevState[name].name, value } }));

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -53,7 +53,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
   }, [selectedTypeId, selectedStatusId, selectedGroupId, handleFieldChange]);
 
   return (
-    <Modal isOpen onOpenChange={onClose}>
+    <Modal isOpen={!state?.success} onOpenChange={onClose}>
       <Button className="hidden">Edit Device</Button>
       <Modal.Backdrop>
         <Modal.Container placement="auto">
@@ -78,7 +78,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                       value={field.name.value}
                       onChange={(e) => handleFieldChange("name", e.target.value)}
                     />
-                    <FieldErrorMessage message={state?.serverErrors.name} isFormLoading={isFormLoading} />
+                    <FieldErrorMessage message={state?.serverErrors?.name} isFormLoading={isFormLoading} />
                   </TextField>
                   <Select
                     name={field.type.name}
@@ -109,7 +109,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                         })}
                       </ListBox>
                     </Select.Popover>
-                    <FieldErrorMessage message={state?.serverErrors.type} isFormLoading={isFormLoading} />
+                    <FieldErrorMessage message={state?.serverErrors?.type} isFormLoading={isFormLoading} />
                   </Select>
                   <Select
                     name={field.status.name}
@@ -140,7 +140,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                         })}
                       </ListBox>
                     </Select.Popover>
-                    <FieldErrorMessage message={state?.serverErrors.status} isFormLoading={isFormLoading} />
+                    <FieldErrorMessage message={state?.serverErrors?.status} isFormLoading={isFormLoading} />
                   </Select>
                   <Select
                     name={field.group.name}
@@ -171,7 +171,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                         })}
                       </ListBox>
                     </Select.Popover>
-                    <FieldErrorMessage message={state?.serverErrors.group} isFormLoading={isFormLoading} />
+                    <FieldErrorMessage message={state?.serverErrors?.group} isFormLoading={isFormLoading} />
                   </Select>
                   <TextField type="text" name={field.serialNumber.name} isRequired>
                     <Label>Serial Number</Label>
@@ -183,7 +183,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                       value={field.serialNumber.value}
                       onChange={(e) => handleFieldChange("serialNumber", e.target.value)}
                     />
-                    <FieldErrorMessage message={state?.serverErrors.serialNumber} isFormLoading={isFormLoading} />
+                    <FieldErrorMessage message={state?.serverErrors?.serialNumber} isFormLoading={isFormLoading} />
                   </TextField>
                   <TextField type="text" name={field.ipAddress.name}>
                     <Label>IP Address</Label>
@@ -195,7 +195,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                       value={field.ipAddress.value}
                       onChange={(e) => handleFieldChange("ipAddress", e.target.value)}
                     />
-                    <FieldErrorMessage message={state?.serverErrors.ipAddress} isFormLoading={isFormLoading} />
+                    <FieldErrorMessage message={state?.serverErrors?.ipAddress} isFormLoading={isFormLoading} />
                   </TextField>
                 </Form>
               </Surface>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -1,29 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { FolderClosedIcon } from "lucide-react";
 
 import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField } from "@heroui/react";
 
 import {
-  type Device,
   type EditDeviceModalProps,
+  generateDeviceFieldIds,
   generateId,
   useDeviceGroups,
   useDeviceStatuses,
   useDeviceTypes,
 } from "@/features/device";
-
-const generateFieldIds = (device: Device) => ({
-  id: { name: "id", value: device.id },
-  name: { name: "name", value: device.name },
-  serialNumber: { name: "serial-number", value: device.serialNumber },
-  ipAddress: { name: "ip-address", value: device.ipAddress ?? "" },
-  type: { name: "type", value: generateId(device.type) },
-  status: { name: "status", value: generateId(device.status) },
-  group: { name: "group", value: generateId(device.group) },
-});
 
 const FORM_ID = "edit-device-form";
 
@@ -34,11 +24,29 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
 
   const { groups } = useDeviceGroups();
 
-  const [field, setField] = useState(generateFieldIds(device));
+  const selectedTypeId = types?.find((type) => type.name === device.type)?.id;
 
-  const handleFieldChange = (name: keyof typeof field, value: string) => {
+  const selectedStatusId = statuses?.find((status) => status.name === device.status)?.id;
+
+  const selectedGroupId = groups?.find((group) => group.name === device.group)?.id;
+
+  const [field, setField] = useState(generateDeviceFieldIds(device));
+
+  const handleFieldChange = useCallback((name: keyof typeof field, value: string) => {
     setField((prevState) => ({ ...prevState, [name]: { name: prevState[name].name, value } }));
-  };
+  }, []);
+
+  useEffect(() => {
+    const updateField = (name: keyof typeof field, value?: string) => {
+      handleFieldChange(name, value ?? "");
+    };
+
+    if (selectedTypeId) updateField("type", selectedTypeId);
+
+    if (selectedStatusId) updateField("status", selectedStatusId);
+
+    if (selectedGroupId) updateField("group", selectedGroupId);
+  }, [selectedTypeId, selectedStatusId, selectedGroupId, handleFieldChange]);
 
   return (
     <Modal isOpen onOpenChange={onClose}>
@@ -83,7 +91,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     <Select.Popover>
                       <ListBox>
                         {types?.map((type) => {
-                          const id = generateId(type.name);
+                          const id = generateId(type.id);
 
                           return (
                             <ListBox.Item key={id} id={id} textValue={type.name}>
@@ -111,7 +119,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     <Select.Popover>
                       <ListBox>
                         {statuses?.map((status) => {
-                          const id = generateId(status.name);
+                          const id = generateId(status.id);
 
                           return (
                             <ListBox.Item key={id} id={id} textValue={status.name}>
@@ -139,7 +147,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     <Select.Popover>
                       <ListBox>
                         {groups?.map((group) => {
-                          const id = generateId(group.name);
+                          const id = generateId(group.id);
 
                           return (
                             <ListBox.Item key={id} id={id} textValue={group.name}>
@@ -180,7 +188,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
               <Button type="button" slot="close" variant="secondary">
                 Cancel
               </Button>
-              <Button type="submit" form={FORM_ID} isDisabled>
+              <Button type="submit" form={FORM_ID}>
                 Save
               </Button>
             </Modal.Footer>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -192,7 +192,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                       value={field.ipAddress.value}
                       onChange={(e) => handleFieldChange("ipAddress", e.target.value)}
                     />
-                    <FieldErrorMessage message={state?.serverErrors.ipAddress} isFormLoading={false} />
+                    <FieldErrorMessage message={state?.serverErrors.ipAddress} isFormLoading={isFormLoading} />
                   </TextField>
                 </Form>
               </Surface>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useActionState, useCallback, useEffect, useState } from "react";
 
 import { FolderClosedIcon } from "lucide-react";
 
@@ -10,6 +10,7 @@ import {
   type EditDeviceModalProps,
   generateDeviceFieldIds,
   generateId,
+  updateDevice,
   useDeviceGroups,
   useDeviceStatuses,
   useDeviceTypes,
@@ -31,6 +32,8 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
   const selectedGroupId = groups?.find((group) => group.name === device.group)?.id;
 
   const [field, setField] = useState(generateDeviceFieldIds(device));
+
+  const [state, formAction, isFormLoading] = useActionState(updateDevice, undefined);
 
   const handleFieldChange = useCallback((name: keyof typeof field, value: string) => {
     setField((prevState) => ({ ...prevState, [name]: { name: prevState[name].name, value } }));
@@ -63,7 +66,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
             </Modal.Header>
             <Modal.Body className="px-1 py-4">
               <Surface variant="default">
-                <Form id={FORM_ID} onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-4">
+                <Form id={FORM_ID} action={formAction} className="flex flex-col gap-4">
                   <TextField type="text" name={field.name.name} isRequired>
                     <Label>Name</Label>
                     <Input
@@ -191,7 +194,12 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
               <Button type="button" slot="close" variant="secondary">
                 Cancel
               </Button>
-              <Button type="submit" form={FORM_ID} isDisabled={isTypesLoading || isStatusesLoading || isGroupsLoading}>
+              <Button
+                type="submit"
+                form={FORM_ID}
+                isPending={isFormLoading}
+                isDisabled={isTypesLoading || isStatusesLoading || isGroupsLoading}
+              >
                 Save
               </Button>
             </Modal.Footer>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -8,6 +8,7 @@ import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField 
 
 import {
   type EditDeviceModalProps,
+  FieldErrorMessage,
   generateDeviceFieldIds,
   generateId,
   updateDevice,
@@ -77,6 +78,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                       value={field.name.value}
                       onChange={(e) => handleFieldChange("name", e.target.value)}
                     />
+                    <FieldErrorMessage message={state?.serverErrors.name} isFormLoading={isFormLoading} />
                   </TextField>
                   <Select
                     name={field.type.name}
@@ -106,6 +108,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                         })}
                       </ListBox>
                     </Select.Popover>
+                    <FieldErrorMessage message={state?.serverErrors.type} isFormLoading={isFormLoading} />
                   </Select>
                   <Select
                     name={field.status.name}
@@ -135,6 +138,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                         })}
                       </ListBox>
                     </Select.Popover>
+                    <FieldErrorMessage message={state?.serverErrors.status} isFormLoading={isFormLoading} />
                   </Select>
                   <Select
                     name={field.group.name}
@@ -164,6 +168,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                         })}
                       </ListBox>
                     </Select.Popover>
+                    <FieldErrorMessage message={state?.serverErrors.group} isFormLoading={isFormLoading} />
                   </Select>
                   <TextField type="text" name={field.serialNumber.name} isRequired>
                     <Label>Serial Number</Label>
@@ -175,6 +180,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                       value={field.serialNumber.value}
                       onChange={(e) => handleFieldChange("serialNumber", e.target.value)}
                     />
+                    <FieldErrorMessage message={state?.serverErrors.serialNumber} isFormLoading={isFormLoading} />
                   </TextField>
                   <TextField type="text" name={field.ipAddress.name}>
                     <Label>IP Address</Label>
@@ -186,6 +192,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                       value={field.ipAddress.value}
                       onChange={(e) => handleFieldChange("ipAddress", e.target.value)}
                     />
+                    <FieldErrorMessage message={state?.serverErrors.ipAddress} isFormLoading={false} />
                   </TextField>
                 </Form>
               </Surface>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -18,11 +18,11 @@ import {
 const FORM_ID = "edit-device-form";
 
 export default function EditDeviceModal({ device, onClose }: EditDeviceModalProps) {
-  const { types } = useDeviceTypes();
+  const { types, loading: isTypesLoading } = useDeviceTypes();
 
-  const { statuses } = useDeviceStatuses();
+  const { statuses, loading: isStatusesLoading } = useDeviceStatuses();
 
-  const { groups } = useDeviceGroups();
+  const { groups, loading: isGroupsLoading } = useDeviceGroups();
 
   const selectedTypeId = types?.find((type) => type.name === device.type)?.id;
 
@@ -82,6 +82,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     isRequired
                     value={field.type.value}
                     onChange={(e) => handleFieldChange("type", String(e))}
+                    isDisabled={isTypesLoading}
                   >
                     <Label>Type</Label>
                     <Select.Trigger className="h-10">
@@ -110,6 +111,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     isRequired
                     value={field.status.value}
                     onChange={(e) => handleFieldChange("status", String(e))}
+                    isDisabled={isStatusesLoading}
                   >
                     <Label>Status</Label>
                     <Select.Trigger className="h-10">
@@ -138,6 +140,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     isRequired
                     value={field.group.value}
                     onChange={(e) => handleFieldChange("group", String(e))}
+                    isDisabled={isGroupsLoading}
                   >
                     <Label>Group</Label>
                     <Select.Trigger className="h-10">

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -191,7 +191,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
               <Button type="button" slot="close" variant="secondary">
                 Cancel
               </Button>
-              <Button type="submit" form={FORM_ID}>
+              <Button type="submit" form={FORM_ID} isDisabled={isTypesLoading || isStatusesLoading || isGroupsLoading}>
                 Save
               </Button>
             </Modal.Footer>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -17,6 +17,7 @@ import {
   useDeviceStatuses,
   useDeviceTypes,
   useFields,
+  useFormSuccess,
 } from "@/features/device";
 
 export default function EditDeviceModal({ device, onClose }: EditDeviceModalProps) {
@@ -36,15 +37,13 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
 
   const [state, formAction, isFormLoading] = useActionState(updateDevice.bind(null, device.id), undefined);
 
+  useFormSuccess(state?.success, onClose);
+
   useEffect(() => {
     if (selectedTypeId) handleFieldChange("type", selectedTypeId);
     if (selectedStatusId) handleFieldChange("status", selectedStatusId);
     if (selectedGroupId) handleFieldChange("group", selectedGroupId);
   }, [handleFieldChange, selectedTypeId, selectedStatusId, selectedGroupId]);
-
-  useEffect(() => {
-    if (state?.success) onClose();
-  }, [state?.success, onClose]);
 
   return (
     <Modal isOpen onOpenChange={onClose}>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -23,7 +23,7 @@ import {
 export default function EditDeviceModal({ device, onClose }: EditDeviceModalProps) {
   const { types, loading: isTypesLoading, error: typesError } = useDeviceTypes();
 
-  const { statuses, loading: isStatusesLoading } = useDeviceStatuses();
+  const { statuses, loading: isStatusesLoading, error: statusesError } = useDeviceStatuses();
 
   const { groups, loading: isGroupsLoading } = useDeviceGroups();
 
@@ -114,7 +114,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     isRequired
                     value={field.status.value}
                     onChange={(e) => handleFieldChange("status", String(e))}
-                    isDisabled={isStatusesLoading}
+                    isDisabled={Boolean(statusesError) || isStatusesLoading}
                     defaultValue={field.status.value}
                   >
                     <Label>Status</Label>
@@ -136,7 +136,10 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                         })}
                       </ListBox>
                     </Select.Popover>
-                    <FieldErrorMessage message={state?.serverErrors?.status} isFormLoading={isFormLoading} />
+                    <FieldErrorMessage
+                      message={statusesError ? statusesError : state?.serverErrors?.status}
+                      isFormLoading={isFormLoading}
+                    />
                   </Select>
                   <Select
                     name={field.group.name}
@@ -204,7 +207,13 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                 type="submit"
                 form={FORM_ID}
                 isPending={isFormLoading}
-                isDisabled={Boolean(typesError) || isTypesLoading || isStatusesLoading || isGroupsLoading}
+                isDisabled={
+                  Boolean(typesError) ||
+                  Boolean(statusesError) ||
+                  isTypesLoading ||
+                  isStatusesLoading ||
+                  isGroupsLoading
+                }
               >
                 Save
               </Button>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -52,8 +52,12 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
     if (selectedGroupId) updateField("group", selectedGroupId);
   }, [selectedTypeId, selectedStatusId, selectedGroupId, handleFieldChange]);
 
+  useEffect(() => {
+    if (state?.success) onClose();
+  }, [state?.success, onClose]);
+
   return (
-    <Modal isOpen={!state?.success} onOpenChange={onClose}>
+    <Modal isOpen onOpenChange={onClose}>
       <Button className="hidden">Edit Device</Button>
       <Modal.Backdrop>
         <Modal.Container placement="auto">

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -88,6 +88,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     value={field.type.value}
                     onChange={(e) => handleFieldChange("type", String(e))}
                     isDisabled={isTypesLoading}
+                    defaultValue={field.type.value}
                   >
                     <Label>Type</Label>
                     <Select.Trigger className="h-10">
@@ -118,6 +119,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     value={field.status.value}
                     onChange={(e) => handleFieldChange("status", String(e))}
                     isDisabled={isStatusesLoading}
+                    defaultValue={field.status.value}
                   >
                     <Label>Status</Label>
                     <Select.Trigger className="h-10">
@@ -148,6 +150,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     value={field.group.value}
                     onChange={(e) => handleFieldChange("group", String(e))}
                     isDisabled={isGroupsLoading}
+                    defaultValue={field.group.value}
                   >
                     <Label>Group</Label>
                     <Select.Trigger className="h-10">

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -9,6 +9,7 @@ import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField 
 import {
   type EditDeviceModalProps,
   FieldErrorMessage,
+  FORM_ID,
   generateDeviceFieldIds,
   generateId,
   updateDevice,
@@ -16,8 +17,6 @@ import {
   useDeviceStatuses,
   useDeviceTypes,
 } from "@/features/device";
-
-const FORM_ID = "edit-device-form";
 
 export default function EditDeviceModal({ device, onClose }: EditDeviceModalProps) {
   const { types, loading: isTypesLoading } = useDeviceTypes();

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/features/device";
 
 export default function EditDeviceModal({ device, onClose }: EditDeviceModalProps) {
-  const { types, loading: isTypesLoading } = useDeviceTypes();
+  const { types, loading: isTypesLoading, error: typesError } = useDeviceTypes();
 
   const { statuses, loading: isStatusesLoading } = useDeviceStatuses();
 
@@ -80,7 +80,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     isRequired
                     value={field.type.value}
                     onChange={(e) => handleFieldChange("type", String(e))}
-                    isDisabled={isTypesLoading}
+                    isDisabled={typesError ? true : isTypesLoading}
                     defaultValue={field.type.value}
                   >
                     <Label>Type</Label>
@@ -102,7 +102,10 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                         })}
                       </ListBox>
                     </Select.Popover>
-                    <FieldErrorMessage message={state?.serverErrors?.type} isFormLoading={isFormLoading} />
+                    <FieldErrorMessage
+                      message={typesError ? typesError : state?.serverErrors?.type}
+                      isFormLoading={isFormLoading}
+                    />
                   </Select>
                   <Select
                     name={field.status.name}
@@ -201,7 +204,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                 type="submit"
                 form={FORM_ID}
                 isPending={isFormLoading}
-                isDisabled={isTypesLoading || isStatusesLoading || isGroupsLoading}
+                isDisabled={Boolean(typesError) || isTypesLoading || isStatusesLoading || isGroupsLoading}
               >
                 Save
               </Button>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -25,7 +25,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
 
   const { statuses, loading: isStatusesLoading, error: statusesError } = useDeviceStatuses();
 
-  const { groups, loading: isGroupsLoading } = useDeviceGroups();
+  const { groups, loading: isGroupsLoading, error: groupsError } = useDeviceGroups();
 
   const selectedTypeId = types?.find((type) => type.name === device.type)?.id;
 
@@ -148,7 +148,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                     isRequired
                     value={field.group.value}
                     onChange={(e) => handleFieldChange("group", String(e))}
-                    isDisabled={isGroupsLoading}
+                    isDisabled={Boolean(groupsError) || isGroupsLoading}
                     defaultValue={field.group.value}
                   >
                     <Label>Group</Label>
@@ -170,7 +170,10 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                         })}
                       </ListBox>
                     </Select.Popover>
-                    <FieldErrorMessage message={state?.serverErrors?.group} isFormLoading={isFormLoading} />
+                    <FieldErrorMessage
+                      message={groupsError ? groupsError : state?.serverErrors?.group}
+                      isFormLoading={isFormLoading}
+                    />
                   </Select>
                   <TextField type="text" name={field.serialNumber.name} isRequired>
                     <Label>Serial Number</Label>
@@ -210,6 +213,7 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
                 isDisabled={
                   Boolean(typesError) ||
                   Boolean(statusesError) ||
+                  Boolean(groupsError) ||
                   isTypesLoading ||
                   isStatusesLoading ||
                   isGroupsLoading

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useCallback, useEffect, useState } from "react";
+import { useActionState, useEffect } from "react";
 
 import { FolderClosedIcon } from "lucide-react";
 
@@ -16,6 +16,7 @@ import {
   useDeviceGroups,
   useDeviceStatuses,
   useDeviceTypes,
+  useFields,
 } from "@/features/device";
 
 export default function EditDeviceModal({ device, onClose }: EditDeviceModalProps) {
@@ -31,25 +32,15 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
 
   const selectedGroupId = groups?.find((group) => group.name === device.group)?.id;
 
-  const [field, setField] = useState(generateDeviceFieldIds(device));
+  const { field, handleFieldChange } = useFields(generateDeviceFieldIds(device));
 
   const [state, formAction, isFormLoading] = useActionState(updateDevice.bind(null, device.id), undefined);
 
-  const handleFieldChange = useCallback((name: keyof typeof field, value: string) => {
-    setField((prevState) => ({ ...prevState, [name]: { name: prevState[name].name, value } }));
-  }, []);
-
   useEffect(() => {
-    const updateField = (name: keyof typeof field, value?: string) => {
-      handleFieldChange(name, value ?? "");
-    };
-
-    if (selectedTypeId) updateField("type", selectedTypeId);
-
-    if (selectedStatusId) updateField("status", selectedStatusId);
-
-    if (selectedGroupId) updateField("group", selectedGroupId);
-  }, [selectedTypeId, selectedStatusId, selectedGroupId, handleFieldChange]);
+    if (selectedTypeId) handleFieldChange("type", selectedTypeId);
+    if (selectedStatusId) handleFieldChange("status", selectedStatusId);
+    if (selectedGroupId) handleFieldChange("group", selectedGroupId);
+  }, [handleFieldChange, selectedTypeId, selectedStatusId, selectedGroupId]);
 
   useEffect(() => {
     if (state?.success) onClose();

--- a/src/features/device/components/field-error-message.tsx
+++ b/src/features/device/components/field-error-message.tsx
@@ -1,0 +1,11 @@
+import { FieldError } from "@heroui/react";
+
+export default function FieldErrorMessage({ message, isFormLoading }: { message?: string; isFormLoading: boolean }) {
+  return message && isFormLoading ? (
+    <p aria-live="polite" className="text-danger px-1 text-xs">
+      {message}
+    </p>
+  ) : (
+    <FieldError />
+  );
+}

--- a/src/features/device/components/field-error-message.tsx
+++ b/src/features/device/components/field-error-message.tsx
@@ -1,7 +1,7 @@
 import { FieldError } from "@heroui/react";
 
 export default function FieldErrorMessage({ message, isFormLoading }: { message?: string; isFormLoading: boolean }) {
-  return message && isFormLoading ? (
+  return message && !isFormLoading ? (
     <p aria-live="polite" className="text-danger px-1 text-xs">
       {message}
     </p>

--- a/src/features/device/hooks/use-fields.tsx
+++ b/src/features/device/hooks/use-fields.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+export default function useFields(initialState: Record<string, { name: string; value: string }>) {
+  const [field, setField] = useState(initialState);
+
+  const handleFieldChange = useCallback((name: keyof typeof field, value: string) => {
+    setField((prevState) => ({ ...prevState, [name]: { name: prevState[name].name, value } }));
+  }, []);
+
+  return {
+    field,
+    handleFieldChange,
+  };
+}

--- a/src/features/device/hooks/use-form-success.tsx
+++ b/src/features/device/hooks/use-form-success.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function useFormSuccess(success?: boolean, handler?: () => void) {
+  useEffect(() => {
+    if (success && handler) {
+      handler();
+    }
+  }, [success, handler]);
+}

--- a/src/features/device/hooks/use-types.tsx
+++ b/src/features/device/hooks/use-types.tsx
@@ -16,7 +16,7 @@ export default function useDeviceTypes() {
 
         setTypes(response.data);
       } catch {
-        setError("Failed to get groups.");
+        setError("Failed to get types.");
       } finally {
         setLoading(false);
       }

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -4,6 +4,8 @@ export * from "./lib/constants";
 
 export * from "./lib/utils";
 
+export * from "./lib/schemas";
+
 export { default as useDeviceGroups } from "./hooks/use-groups";
 
 export { default as useDeviceStatuses } from "./hooks/use-statuses";

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -6,6 +6,8 @@ export * from "./lib/utils";
 
 export * from "./lib/schemas";
 
+export * from "./lib/actions";
+
 export { default as useDeviceGroups } from "./hooks/use-groups";
 
 export { default as useDeviceStatuses } from "./hooks/use-statuses";

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -16,6 +16,8 @@ export { default as useDeviceTypes } from "./hooks/use-types";
 
 export { default as useFields } from "./hooks/use-fields";
 
+export { default as useFormSuccess } from "./hooks/use-form-success";
+
 export { default as TotalDevices } from "./components/total-devices";
 
 export { default as DeviceStatSkeleton } from "./components/device-stat-skeleton";

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -31,3 +31,5 @@ export { default as DeviceActions } from "./components/device-actions";
 export { default as EditDeviceModal } from "./components/edit-device-modal";
 
 export { default as MoveDeviceModal } from "./components/move-device-modal";
+
+export { default as FieldErrorMessage } from "./components/field-error-message";

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -14,6 +14,8 @@ export { default as useDeviceStatuses } from "./hooks/use-statuses";
 
 export { default as useDeviceTypes } from "./hooks/use-types";
 
+export { default as useFields } from "./hooks/use-fields";
+
 export { default as TotalDevices } from "./components/total-devices";
 
 export { default as DeviceStatSkeleton } from "./components/device-stat-skeleton";

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -13,6 +13,7 @@ import { devicesTable } from "@/db/schemas";
 import { EditDeviceSchema } from "@/features/device";
 
 type PreviousState = {
+  success: boolean;
   serverErrors?: Partial<{
     name: string;
     type: string;
@@ -40,6 +41,7 @@ export const updateDevice = async (deviceId: string, _previousState: PreviousSta
       const { fieldErrors } = z.flattenError(parsedFields.error);
 
       return {
+        success: false,
         serverErrors: {
           name: fieldErrors.name?.toString(),
           type: fieldErrors.typeId?.toString(),
@@ -66,9 +68,14 @@ export const updateDevice = async (deviceId: string, _previousState: PreviousSta
     });
   } catch {
     return {
+      success: false,
       serverErrors: {
         ipAddress: "A server error has occurred.",
       },
     };
   }
+
+  return {
+    success: true,
+  };
 };

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -18,9 +18,9 @@ type PreviousState = {
 export const updateDevice = async (_previousState: PreviousState | undefined, formData: FormData) => {
   const parsedFields = EditDeviceSchema.safeParse({
     name: formData.get("name"),
-    type: formData.get("type"),
-    status: formData.get("status"),
-    group: formData.get("group"),
+    typeId: formData.get("type"),
+    statusId: formData.get("status"),
+    groupId: formData.get("group"),
     ipAddress: formData.get("ip-address"),
     serialNumber: formData.get("serial-number"),
   });
@@ -32,9 +32,9 @@ export const updateDevice = async (_previousState: PreviousState | undefined, fo
       return {
         serverErrors: {
           name: fieldErrors.name?.toString(),
-          type: fieldErrors.type?.toString(),
-          status: fieldErrors.status?.toString(),
-          group: fieldErrors.group?.toString(),
+          type: fieldErrors.typeId?.toString(),
+          status: fieldErrors.statusId?.toString(),
+          group: fieldErrors.groupId?.toString(),
           ipAddress: fieldErrors.ipAddress?.toString(),
           serialNumber: fieldErrors.serialNumber?.toString(),
         },

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -2,6 +2,14 @@
 
 import { z } from "zod";
 
+import { eq, sql } from "drizzle-orm";
+
+import { db } from "@/db/client";
+
+import { getSession } from "@/dal/session";
+
+import { devicesTable } from "@/db/schemas";
+
 import { EditDeviceSchema } from "@/features/device";
 
 type PreviousState = {
@@ -15,7 +23,9 @@ type PreviousState = {
   }>;
 };
 
-export const updateDevice = async (_previousState: PreviousState | undefined, formData: FormData) => {
+export const updateDevice = async (deviceId: string, _previousState: PreviousState | undefined, formData: FormData) => {
+  const { userId } = await getSession();
+
   const parsedFields = EditDeviceSchema.safeParse({
     name: formData.get("name"),
     typeId: formData.get("type"),
@@ -41,7 +51,19 @@ export const updateDevice = async (_previousState: PreviousState | undefined, fo
       };
     }
 
-    // Update the resource
+    await db.transaction(async (tx) => {
+      await tx
+        .update(devicesTable)
+        .set({
+          name: parsedFields.data.name,
+          typeId: sql`(SELECT id FROM device_types WHERE id = ${parsedFields.data.typeId} AND user_id = ${userId})`,
+          statusId: sql`(SELECT id FROM device_statuses WHERE id = ${parsedFields.data.statusId} AND user_id = ${userId})`,
+          groupId: sql`(SELECT id FROM device_groups WHERE id = ${parsedFields.data.groupId} AND user_id = ${userId})`,
+          ipAddress: parsedFields.data.ipAddress,
+          serialNumber: parsedFields.data.serialNumber,
+        })
+        .where(eq(devicesTable.id, deviceId));
+    });
   } catch {
     return {
       serverErrors: {

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 
 import { eq, sql } from "drizzle-orm";
 
+import { revalidatePath } from "next/cache";
+
 import { db } from "@/db/client";
 
 import { getSession } from "@/dal/session";
@@ -74,6 +76,8 @@ export const updateDevice = async (deviceId: string, _previousState: PreviousSta
       },
     };
   }
+
+  revalidatePath("/dashboard");
 
   return {
     success: true,

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { z } from "zod";
+
+import { EditDeviceSchema } from "@/features/device";
+
+type PreviousState = {
+  serverErrors?: Partial<{
+    name: string;
+    type: string;
+    status: string;
+    group: string;
+    ipAddress: string;
+    serialNumber: string;
+  }>;
+};
+
+export const updateDevice = async (_previousState: PreviousState | undefined, formData: FormData) => {
+  const parsedFields = EditDeviceSchema.safeParse({
+    name: formData.get("name"),
+    type: formData.get("type"),
+    status: formData.get("status"),
+    group: formData.get("group"),
+    ipAddress: formData.get("ip-address"),
+    serialNumber: formData.get("serial-number"),
+  });
+
+  try {
+    if (!parsedFields.success) {
+      const { fieldErrors } = z.flattenError(parsedFields.error);
+
+      return {
+        serverErrors: {
+          name: fieldErrors.name?.toString(),
+          type: fieldErrors.type?.toString(),
+          status: fieldErrors.status?.toString(),
+          group: fieldErrors.group?.toString(),
+          ipAddress: fieldErrors.ipAddress?.toString(),
+          serialNumber: fieldErrors.serialNumber?.toString(),
+        },
+      };
+    }
+
+    // Update the resource
+  } catch {
+    return {
+      serverErrors: {
+        ipAddress: "A server error has occurred.",
+      },
+    };
+  }
+};

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -1,1 +1,3 @@
 export const TABLE_COLUMNS = ["Name", "Type", "Status", "Group", "Serial Number", "Actions"];
+
+export const FORM_ID = "device-form";

--- a/src/features/device/lib/schemas.ts
+++ b/src/features/device/lib/schemas.ts
@@ -2,9 +2,9 @@ import { z } from "zod";
 
 export const EditDeviceSchema = z.object({
   name: z.string().min(1, "Name is required.").max(255, "Name is too long."),
-  type: z.string().min(1, "Type is required.").max(255, "Type is too long."),
-  status: z.string().min(1, "Status is required.").max(255, "Status is too long."),
-  group: z.string().min(1, "Group is required").max(255, "Group is too long."),
+  typeId: z.string().min(1, "Type is required.").max(255, "Type is too long."),
+  statusId: z.string().min(1, "Status is required.").max(255, "Status is too long."),
+  groupId: z.string().min(1, "Group is required").max(255, "Group is too long."),
   serialNumber: z.string().min(1, "Serial number is required.").max(64, "Serial Number is too long."),
   ipAddress: z.union([z.string().max(0), z.ipv4()], "Invalid IP address."),
 });

--- a/src/features/device/lib/schemas.ts
+++ b/src/features/device/lib/schemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const EditDeviceSchema = z.object({
+  name: z.string().min(1, "Name is required.").max(255, "Name is too long."),
+  type: z.string().min(1, "Type is required.").max(255, "Type is too long."),
+  status: z.string().min(1, "Status is required.").max(255, "Status is too long."),
+  group: z.string().min(1, "Group is required").max(255, "Group is too long."),
+  serialNumber: z.string().min(1, "Serial number is required.").max(64, "Serial Number is too long."),
+  ipAddress: z.union([z.string().max(0), z.ipv4()], "Invalid IP address."),
+});

--- a/src/features/device/lib/utils.ts
+++ b/src/features/device/lib/utils.ts
@@ -1,5 +1,7 @@
 import type { ChipVariants } from "@heroui/styles";
 
+import type { Device } from "@/features/device";
+
 export const getChipColorByStatus = (status: string): ChipVariants["color"] => {
   switch (status) {
     case "In Use":
@@ -14,3 +16,13 @@ export const getChipColorByStatus = (status: string): ChipVariants["color"] => {
 };
 
 export const generateId = (value: string, separator: string = "-") => value.toLowerCase().split(" ").join(separator);
+
+export const generateDeviceFieldIds = (data: Device) => ({
+  id: { name: "id", value: data.id },
+  name: { name: "name", value: data.name },
+  serialNumber: { name: "serial-number", value: data.serialNumber },
+  ipAddress: { name: "ip-address", value: data.ipAddress ?? "" },
+  type: { name: "type", value: "" },
+  status: { name: "status", value: "" },
+  group: { name: "group", value: "" },
+});


### PR DESCRIPTION
This PR introduces the server action to allow users to update a device.

## Changes
- Added an ID to the form and linked it to the submit button.
- Added an effect that updates the field values once the data has finished loading. The fields are disabled on first render.
- Disabled the button of the form until some field values have loaded.
- Built the schema for editing a device.
- Built the form action that allows users to persist to the database on a successful form submission.
- Added logic to show error messages on invalid fields.
- Kept state of the form in case the form submission fails.
- Re-validated the dashboard page to show the updated data changes.
- Built `useFields` hook for handling logic of any field changes.
- Built `useFormSuccess` hook for handling form submission status.
- Added logic to prevent form submissions if types, statuses, or groups data fails to load.