### PR TITLE
Feature/limit rows and order recent devices

### DIFF
--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -55,7 +55,7 @@ export const getDevicesCountByStatus = async (status: string): Promise<ActionRes
   }
 };
 
-export const getDevices = async (): Promise<ActionResult<Device[]>> => {
+export const getDevices = async (limit?: number): Promise<ActionResult<Device[]>> => {
   try {
     const session = await getSession();
 
@@ -75,7 +75,7 @@ export const getDevices = async (): Promise<ActionResult<Device[]>> => {
       .innerJoin(deviceGroupsTable, eq(devicesTable.groupId, deviceGroupsTable.id))
       .where(eq(devicesTable.userId, session.userId))
       .orderBy(desc(devicesTable.name))
-      .limit(MAX_ROWS);
+      .limit(limit ?? MAX_ROWS);
 
     return {
       data,

--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -74,7 +74,7 @@ export const getDevices = async (limit?: number): Promise<ActionResult<Device[]>
       .innerJoin(deviceStatusesTable, eq(devicesTable.statusId, deviceStatusesTable.id))
       .innerJoin(deviceGroupsTable, eq(devicesTable.groupId, deviceGroupsTable.id))
       .where(eq(devicesTable.userId, session.userId))
-      .orderBy(desc(devicesTable.name))
+      .orderBy(desc(devicesTable.createdAt))
       .limit(limit ?? MAX_ROWS);
 
     return {

--- a/src/features/device/components/recent-devices.tsx
+++ b/src/features/device/components/recent-devices.tsx
@@ -9,7 +9,7 @@ import { getDevices } from "@/dal/device";
 import { DeviceActions, getChipColorByStatus, TABLE_COLUMNS } from "@/features/device";
 
 export default async function RecentDevices() {
-  const { data, error } = await getDevices();
+  const { data, error } = await getDevices(5);
 
   const hasNoData = !data?.length && data?.length === 0;
 


### PR DESCRIPTION
This PR retrieves only five records from the database of recently created devices. It also updated the query to order the records by their creation date.