### PR TITLE
Feature/move device action

### DIFF
--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -67,7 +67,9 @@ export default function DeviceActions({ device }: { device: Device }) {
 
       {modal === "edit" && <EditDeviceModal device={device} onClose={() => setModal(null)} />}
 
-      {modal === "move" && <MoveDeviceModal deviceGroup={device.group} onClose={() => setModal(null)} />}
+      {modal === "move" && (
+        <MoveDeviceModal deviceId={device.id} deviceGroup={device.group} onClose={() => setModal(null)} />
+      )}
     </>
   );
 }

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -1,17 +1,33 @@
 "use client";
 
-import { useState } from "react";
+import { useActionState, useEffect } from "react";
 
 import { FolderClosedIcon } from "lucide-react";
 
-import { Button, Form, type Key, Label, ListBox, Modal, Select, Surface } from "@heroui/react";
+import { Button, Form, Label, ListBox, Modal, Select, Surface } from "@heroui/react";
 
-import { FieldErrorMessage, generateId, type MoveDeviceModalProps, useDeviceGroups } from "@/features/device";
+import {
+  FieldErrorMessage,
+  FORM_ID,
+  generateId,
+  moveDevice,
+  type MoveDeviceModalProps,
+  useDeviceGroups,
+  useFields,
+} from "@/features/device";
 
-export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModalProps) {
+export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: MoveDeviceModalProps) {
   const { groups, loading, error } = useDeviceGroups();
 
-  const [selectedGroup, setSelectedGroup] = useState<Key | null>(generateId(deviceGroup));
+  const selectedGroupId = groups?.find((group) => group.name === deviceGroup)?.id;
+
+  const { field, handleFieldChange } = useFields({ group: { name: "group", value: "" } });
+
+  const [state, formAction, isFormLoading] = useActionState(moveDevice.bind(null, deviceId), undefined);
+
+  useEffect(() => {
+    if (selectedGroupId) handleFieldChange("group", selectedGroupId);
+  }, [handleFieldChange, selectedGroupId]);
 
   return (
     <Modal isOpen onOpenChange={onClose}>
@@ -28,15 +44,16 @@ export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModa
             </Modal.Header>
             <Modal.Body className="px-1 py-4">
               <Surface variant="default">
-                <Form id="edit-device-form" onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-4">
+                <Form id={FORM_ID} action={formAction} className="flex flex-col gap-4">
                   <Select
-                    name="group"
+                    name={field.group.name}
                     variant="secondary"
                     placeholder="Select group"
                     isRequired
-                    value={selectedGroup}
-                    onChange={(value) => setSelectedGroup(value)}
+                    value={field.group.value}
+                    onChange={(value) => handleFieldChange("group", String(value))}
                     isDisabled={loading || Boolean(error)}
+                    defaultValue={field.group.value}
                   >
                     <Label>Group</Label>
                     <Select.Trigger className="h-10">
@@ -46,7 +63,7 @@ export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModa
                     <Select.Popover>
                       <ListBox>
                         {groups?.map((group) => {
-                          const id = generateId(group.name);
+                          const id = generateId(group.id);
 
                           return (
                             <ListBox.Item key={id} id={id} textValue={group.name}>
@@ -66,7 +83,7 @@ export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModa
               <Button type="button" slot="close" variant="secondary">
                 Cancel
               </Button>
-              <Button type="submit" isDisabled={loading}>
+              <Button type="submit" form={FORM_ID} isPending={isFormLoading} isDisabled={loading}>
                 Save
               </Button>
             </Modal.Footer>

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -14,6 +14,7 @@ import {
   type MoveDeviceModalProps,
   useDeviceGroups,
   useFields,
+  useFormSuccess,
 } from "@/features/device";
 
 export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: MoveDeviceModalProps) {
@@ -28,6 +29,8 @@ export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: Move
   useEffect(() => {
     if (selectedGroupId) handleFieldChange("group", selectedGroupId);
   }, [handleFieldChange, selectedGroupId]);
+
+  useFormSuccess(state?.success, onClose);
 
   return (
     <Modal isOpen onOpenChange={onClose}>

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/features/device";
 
 export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: MoveDeviceModalProps) {
-  const { groups, loading, error: groupsError } = useDeviceGroups();
+  const { groups, loading: isGroupsLoading, error: groupsError } = useDeviceGroups();
 
   const selectedGroupId = groups?.find((group) => group.name === deviceGroup)?.id;
 
@@ -55,7 +55,7 @@ export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: Move
                     isRequired
                     value={field.group.value}
                     onChange={(value) => handleFieldChange("group", String(value))}
-                    isDisabled={loading || Boolean(groupsError)}
+                    isDisabled={isGroupsLoading || Boolean(groupsError)}
                     defaultValue={field.group.value}
                   >
                     <Label>Group</Label>
@@ -89,7 +89,12 @@ export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: Move
               <Button type="button" slot="close" variant="secondary">
                 Cancel
               </Button>
-              <Button type="submit" form={FORM_ID} isPending={isFormLoading} isDisabled={loading}>
+              <Button
+                type="submit"
+                form={FORM_ID}
+                isPending={isFormLoading}
+                isDisabled={isGroupsLoading || Boolean(groupsError)}
+              >
                 Save
               </Button>
             </Modal.Footer>

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -26,11 +26,11 @@ export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: Move
 
   const [state, formAction, isFormLoading] = useActionState(moveDevice.bind(null, deviceId), undefined);
 
+  useFormSuccess(state?.success, onClose);
+
   useEffect(() => {
     if (selectedGroupId) handleFieldChange("group", selectedGroupId);
   }, [handleFieldChange, selectedGroupId]);
-
-  useFormSuccess(state?.success, onClose);
 
   return (
     <Modal isOpen onOpenChange={onClose}>

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -6,10 +6,10 @@ import { FolderClosedIcon } from "lucide-react";
 
 import { Button, Form, type Key, Label, ListBox, Modal, Select, Surface } from "@heroui/react";
 
-import { generateId, type MoveDeviceModalProps, useDeviceGroups } from "@/features/device";
+import { FieldErrorMessage, generateId, type MoveDeviceModalProps, useDeviceGroups } from "@/features/device";
 
 export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModalProps) {
-  const { groups, loading } = useDeviceGroups();
+  const { groups, loading, error } = useDeviceGroups();
 
   const [selectedGroup, setSelectedGroup] = useState<Key | null>(generateId(deviceGroup));
 
@@ -36,7 +36,7 @@ export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModa
                     isRequired
                     value={selectedGroup}
                     onChange={(value) => setSelectedGroup(value)}
-                    isDisabled={loading}
+                    isDisabled={loading || Boolean(error)}
                   >
                     <Label>Group</Label>
                     <Select.Trigger className="h-10">
@@ -57,6 +57,7 @@ export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModa
                         })}
                       </ListBox>
                     </Select.Popover>
+                    <FieldErrorMessage message={error ? error : undefined} isFormLoading={false} />
                   </Select>
                 </Form>
               </Surface>

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/features/device";
 
 export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: MoveDeviceModalProps) {
-  const { groups, loading, error } = useDeviceGroups();
+  const { groups, loading, error: groupsError } = useDeviceGroups();
 
   const selectedGroupId = groups?.find((group) => group.name === deviceGroup)?.id;
 
@@ -52,7 +52,7 @@ export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: Move
                     isRequired
                     value={field.group.value}
                     onChange={(value) => handleFieldChange("group", String(value))}
-                    isDisabled={loading || Boolean(error)}
+                    isDisabled={loading || Boolean(groupsError)}
                     defaultValue={field.group.value}
                   >
                     <Label>Group</Label>
@@ -74,7 +74,10 @@ export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: Move
                         })}
                       </ListBox>
                     </Select.Popover>
-                    <FieldErrorMessage message={error ? error : undefined} isFormLoading={false} />
+                    <FieldErrorMessage
+                      message={groupsError ? groupsError : state?.serverErrors?.group}
+                      isFormLoading={isFormLoading}
+                    />
                   </Select>
                 </Form>
               </Surface>

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -9,7 +9,7 @@ import { Button, Form, type Key, Label, ListBox, Modal, Select, Surface } from "
 import { generateId, type MoveDeviceModalProps, useDeviceGroups } from "@/features/device";
 
 export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModalProps) {
-  const { groups } = useDeviceGroups();
+  const { groups, loading } = useDeviceGroups();
 
   const [selectedGroup, setSelectedGroup] = useState<Key | null>(generateId(deviceGroup));
 
@@ -36,6 +36,7 @@ export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModa
                     isRequired
                     value={selectedGroup}
                     onChange={(value) => setSelectedGroup(value)}
+                    isDisabled={loading}
                   >
                     <Label>Group</Label>
                     <Select.Trigger className="h-10">
@@ -64,7 +65,7 @@ export default function MoveDeviceModal({ deviceGroup, onClose }: MoveDeviceModa
               <Button type="button" slot="close" variant="secondary">
                 Cancel
               </Button>
-              <Button type="submit" isDisabled>
+              <Button type="submit" isDisabled={loading}>
                 Save
               </Button>
             </Modal.Footer>

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -12,7 +12,7 @@ import { getSession } from "@/dal/session";
 
 import { devicesTable } from "@/db/schemas";
 
-import { EditDeviceSchema } from "@/features/device";
+import { EditDeviceSchema, MoveDeviceSchema } from "@/features/device";
 
 type PreviousState = {
   success: boolean;
@@ -73,6 +73,55 @@ export const updateDevice = async (deviceId: string, _previousState: PreviousSta
       success: false,
       serverErrors: {
         ipAddress: "A server error has occurred.",
+      },
+    };
+  }
+
+  revalidatePath("/dashboard");
+
+  return {
+    success: true,
+  };
+};
+
+type MoveDevicePrevState = { success: boolean; serverErrors?: Partial<{ group: string }> };
+
+export const moveDevice = async (
+  deviceId: string,
+  _previousState: MoveDevicePrevState | undefined,
+  formData: FormData,
+) => {
+  try {
+    const { userId } = await getSession();
+
+    const parsedFields = MoveDeviceSchema.safeParse({
+      groupId: formData.get("group"),
+    });
+
+    if (!parsedFields.success) {
+      const { fieldErrors } = z.flattenError(parsedFields.error);
+
+      return {
+        success: false,
+        serverErrors: {
+          group: fieldErrors.groupId?.toString(),
+        },
+      };
+    }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(devicesTable)
+        .set({
+          groupId: sql`(SELECT id FROM device_groups WHERE id = ${parsedFields.data.groupId} AND user_id = ${userId})`,
+        })
+        .where(eq(devicesTable.id, deviceId));
+    });
+  } catch {
+    return {
+      success: false,
+      serverErrors: {
+        group: "A server error has occurred.",
       },
     };
   }

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -8,4 +8,4 @@ export type Device = Pick<typeof devicesTable.$inferSelect, "id" | "name" | "ser
 
 export type EditDeviceModalProps = { device: Device; onClose: () => void };
 
-export type MoveDeviceModalProps = { deviceGroup: string; onClose: () => void };
+export type MoveDeviceModalProps = { deviceId: string; deviceGroup: string; onClose: () => void };

--- a/src/features/device/lib/schemas.ts
+++ b/src/features/device/lib/schemas.ts
@@ -8,3 +8,7 @@ export const EditDeviceSchema = z.object({
   serialNumber: z.string().min(1, "Serial number is required.").max(64, "Serial Number is too long."),
   ipAddress: z.union([z.string().max(0), z.ipv4()], "Invalid IP address."),
 });
+
+export const MoveDeviceSchema = EditDeviceSchema.pick({
+  groupId: true,
+});


### PR DESCRIPTION
This PR further enhances the move device modal. It allows users to move a device to a different group.

## Changes
- Added logic to disable the form until data from `useDeviceGroups` is fully loaded.
- Added logic to show an error message if the groups fail to load.
- Built the move device schema using `pick()` via `zod`.
- Built the form action to allow saving changes to the database.