### PR TITLE
Feature/device copy id and share

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { APP_DESC, APP_NAME } from "@/lib/constants";
 
+import { Toast } from "@heroui/react";
+
 import { ThemeProvider } from "@wrksz/themes/next";
 
 const interSans = Inter({
@@ -27,6 +29,7 @@ export default function RootLayout({
     <html lang="en" className={`${interSans.variable} h-full antialiased`} suppressHydrationWarning>
       <body className="flex min-h-full flex-col">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          <Toast.Provider />
           {children}
         </ThemeProvider>
       </body>

--- a/src/features/dashboard/hooks/use-timer.tsx
+++ b/src/features/dashboard/hooks/use-timer.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { TIMER_IN_MILLISECONDS } from "@/features/dashboard";
+
+export default function useTimer() {
+  const [state, setState] = useState<{ isRunning: boolean; delay: number }>({
+    isRunning: false,
+    delay: TIMER_IN_MILLISECONDS,
+  });
+
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const startHandler = (delay = TIMER_IN_MILLISECONDS) => {
+    if (timerRef.current) resetHandler();
+
+    setState({
+      isRunning: true,
+      delay,
+    });
+
+    timerRef.current = setTimeout(stopHandler, delay);
+  };
+
+  const stopHandler = () => {
+    setState({
+      isRunning: false,
+      delay: TIMER_IN_MILLISECONDS,
+    });
+  };
+
+  const resetHandler = () => {
+    clearTimeout(timerRef.current ? timerRef.current : undefined);
+  };
+
+  useEffect(() => {
+    return () => resetHandler();
+  }, []);
+
+  return {
+    isRunning: state.isRunning,
+    startTimer: startHandler,
+  };
+}

--- a/src/features/dashboard/index.ts
+++ b/src/features/dashboard/index.ts
@@ -6,6 +6,8 @@ export * from "./lib/config";
 
 export * from "./lib/utils";
 
+export { default as useTimer } from "./hooks/use-timer";
+
 export { default as Sidebar } from "./components/sidebar";
 
 export { default as NavList } from "./components/nav-list";

--- a/src/features/dashboard/lib/constants.ts
+++ b/src/features/dashboard/lib/constants.ts
@@ -9,3 +9,5 @@ export const AVATAR_FALLBACK_DELAY = 600;
 export const DASHBOARD_TITLE = "Dashboard";
 
 export const DASHBOARD_DESC = "An overview of your devices, location device data, and health status.";
+
+export const TIMER_IN_MILLISECONDS = 1500;

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-import { Button, Dropdown, type Key, Label, Separator } from "@heroui/react";
+import { Button, Dropdown, type Key, Label, Separator, toast } from "@heroui/react";
 
 import {
   CircleEllipsisIcon,
@@ -14,10 +14,21 @@ import {
   Trash2Icon,
 } from "lucide-react";
 
-import { type Device, EditDeviceModal, MoveDeviceModal } from "@/features/device";
+import { type Device, EditDeviceModal, MoveDeviceModal, useCopyToClipboard } from "@/features/device";
 
 export default function DeviceActions({ device }: { device: Device }) {
+  const { copy } = useCopyToClipboard();
+
   const [modal, setModal] = useState<Key | null>(null);
+
+  const copyDeviceId = async () => {
+    try {
+      await copy(device.id);
+      toast.success("Device ID copied to clipboard.");
+    } catch {
+      toast.danger("Failed to copy device ID.");
+    }
+  };
 
   useEffect(() => {
     if (modal === "view") {
@@ -48,7 +59,7 @@ export default function DeviceActions({ device }: { device: Device }) {
               <Label>Move...</Label>
             </Dropdown.Item>
             <Separator />
-            <Dropdown.Item id="copy-id" textValue="Copy ID">
+            <Dropdown.Item id="copy-id" textValue="Copy ID" onAction={copyDeviceId}>
               <CopyIcon className="text-muted size-4" />
               <Label>Copy ID</Label>
             </Dropdown.Item>

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -14,7 +14,7 @@ import {
   Trash2Icon,
 } from "lucide-react";
 
-import { type Device, EditDeviceModal, MoveDeviceModal, useCopyToClipboard } from "@/features/device";
+import { type Device, EditDeviceModal, MoveDeviceModal, ShareDeviceModal, useCopyToClipboard } from "@/features/device";
 
 export default function DeviceActions({ device }: { device: Device }) {
   const { copy } = useCopyToClipboard();
@@ -81,6 +81,8 @@ export default function DeviceActions({ device }: { device: Device }) {
       {modal === "move" && (
         <MoveDeviceModal deviceId={device.id} deviceGroup={device.group} onClose={() => setModal(null)} />
       )}
+
+      {modal === "share" && <ShareDeviceModal deviceId={device.id} onClose={() => setModal(null)} />}
     </>
   );
 }

--- a/src/features/device/components/share-device-modal.tsx
+++ b/src/features/device/components/share-device-modal.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { CheckIcon, CopyIcon, Share2Icon } from "lucide-react";
+
+import { Button, InputGroup, Label, Modal, Surface, TextField } from "@heroui/react";
+
+import { useTimer } from "@/features/dashboard";
+
+import { useCopyToClipboard, type ShareDeviceModalProps } from "@/features/device";
+
+const getUrlProtocolAndDomain = () => {
+  const { protocol, host } = window.location;
+  return `${protocol}//${host}`;
+};
+
+export default function ShareDeviceModal({ deviceId, onClose }: ShareDeviceModalProps) {
+  const { copy } = useCopyToClipboard();
+
+  const { isRunning, startTimer } = useTimer();
+
+  const shareUrl = `${getUrlProtocolAndDomain()}/devices/${deviceId}`;
+
+  const copyShareUrl = async () => {
+    await copy(shareUrl);
+    startTimer();
+  };
+
+  return (
+    <Modal isOpen onOpenChange={onClose}>
+      <Button className="hidden">Move Device</Button>
+      <Modal.Backdrop>
+        <Modal.Container placement="auto">
+          <Modal.Dialog className="sm:max-w-md">
+            <Modal.CloseTrigger />
+            <Modal.Header>
+              <Modal.Icon className="bg-default text-foreground">
+                <Share2Icon className="size-5" />
+              </Modal.Icon>
+              <Modal.Heading>Share</Modal.Heading>
+              <p className="text-muted mt-1.5_ text-sm leading-5">
+                Anyone who has this link will be able to view this.
+              </p>
+            </Modal.Header>
+            <Modal.Body className="px-1 py-4">
+              <Surface variant="default">
+                <TextField defaultValue={shareUrl} name="share" isReadOnly>
+                  <Label className="sr-only">Share</Label>
+                  <InputGroup variant="secondary">
+                    <InputGroup.Input className="w-full_" />
+                    <InputGroup.Suffix className="pr-0" />
+                    <Button aria-label="Copy" size="sm" variant="ghost" isIconOnly onPress={copyShareUrl}>
+                      {isRunning ? <CheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
+                    </Button>
+                  </InputGroup>
+                </TextField>
+              </Surface>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button type="button" slot="close">
+                Close
+              </Button>
+            </Modal.Footer>
+          </Modal.Dialog>
+        </Modal.Container>
+      </Modal.Backdrop>
+    </Modal>
+  );
+}

--- a/src/features/device/hooks/use-copy-to-clipboard.tsx
+++ b/src/features/device/hooks/use-copy-to-clipboard.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+export default function useCopyToClipboard() {
+  const handleCopy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      throw new Error("Failed to copy text to clipboard.");
+    }
+  };
+
+  return {
+    copy: handleCopy,
+  };
+}

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -18,6 +18,8 @@ export { default as useFields } from "./hooks/use-fields";
 
 export { default as useFormSuccess } from "./hooks/use-form-success";
 
+export { default as useCopyToClipboard } from "./hooks/use-copy-to-clipboard";
+
 export { default as TotalDevices } from "./components/total-devices";
 
 export { default as DeviceStatSkeleton } from "./components/device-stat-skeleton";

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -38,4 +38,6 @@ export { default as EditDeviceModal } from "./components/edit-device-modal";
 
 export { default as MoveDeviceModal } from "./components/move-device-modal";
 
+export { default as ShareDeviceModal } from "./components/share-device-modal";
+
 export { default as FieldErrorMessage } from "./components/field-error-message";

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -9,3 +9,5 @@ export type Device = Pick<typeof devicesTable.$inferSelect, "id" | "name" | "ser
 export type EditDeviceModalProps = { device: Device; onClose: () => void };
 
 export type MoveDeviceModalProps = { deviceId: string; deviceGroup: string; onClose: () => void };
+
+export type ShareDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose">;


### PR DESCRIPTION
This PR introduces a modal that allows users to share a direct link to the device resource.

## Changes
- Built the `ShareDeviceModal` component.
- Created a function that copies the device ID to the clipboard using the clipboard property via the `Navigator` interface.
- Built the `useTimer` hook.
- Showed a checkmark when the URL was successfully copied to the clipboard. A timer is set afterwards, which resets `isRunning` to false. Once the timer is done, the checkmark icon is no longer visible.
- Performed a reset on the timer when the copy button is clicked consecutively.