### PR TITLE
Feature/delete device modal

### DIFF
--- a/src/features/device/components/delete-device-modal.tsx
+++ b/src/features/device/components/delete-device-modal.tsx
@@ -1,12 +1,18 @@
 "use client";
 
+import { useActionState } from "react";
+
 import { Trash2Icon } from "lucide-react";
 
-import { AlertDialog, Button, Form } from "@heroui/react";
+import { AlertDialog, Button, ErrorMessage, Form } from "@heroui/react";
 
-import type { DeleteDeviceModalProps } from "@/features/device";
+import { deleteDevice, useFormSuccess, type DeleteDeviceModalProps } from "@/features/device";
 
-export default function DeleteDeviceModal({ deviceName, onClose }: DeleteDeviceModalProps) {
+export default function DeleteDeviceModal({ deviceId, deviceName, onClose }: DeleteDeviceModalProps) {
+  const [state, formAction, isFormLoading] = useActionState(deleteDevice.bind(null, deviceId), undefined);
+
+  useFormSuccess(state?.success, onClose);
+
   return (
     <AlertDialog isOpen onOpenChange={onClose}>
       <Button type="button" variant="danger" className="hidden">
@@ -24,16 +30,16 @@ export default function DeleteDeviceModal({ deviceName, onClose }: DeleteDeviceM
             </AlertDialog.Header>
             <AlertDialog.Body>
               <p>
-                This will permanently delete <strong>{deviceName}</strong> and all of its data. This action cannot be
-                undone.
+                This will permanently delete <strong>{deviceName}</strong>. This action cannot be undone.
               </p>
+              {state?.serverError && <ErrorMessage>{state.serverError}</ErrorMessage>}
             </AlertDialog.Body>
             <AlertDialog.Footer>
               <Button type="button" slot="close" variant="secondary">
                 Cancel
               </Button>
-              <Form onSubmit={(e) => e.preventDefault()}>
-                <Button type="submit" variant="danger">
+              <Form action={formAction}>
+                <Button type="submit" variant="danger" isPending={isFormLoading}>
                   Delete
                 </Button>
               </Form>

--- a/src/features/device/components/delete-device-modal.tsx
+++ b/src/features/device/components/delete-device-modal.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Trash2Icon } from "lucide-react";
+
+import { AlertDialog, Button, Form } from "@heroui/react";
+
+import type { DeleteDeviceModalProps } from "@/features/device";
+
+export default function DeleteDeviceModal({ deviceName, onClose }: DeleteDeviceModalProps) {
+  return (
+    <AlertDialog isOpen onOpenChange={onClose}>
+      <Button type="button" variant="danger" className="hidden">
+        Delete Device
+      </Button>
+      <AlertDialog.Backdrop>
+        <AlertDialog.Container>
+          <AlertDialog.Dialog className="sm:max-w-md">
+            <AlertDialog.CloseTrigger />
+            <AlertDialog.Header>
+              <AlertDialog.Icon status="danger">
+                <Trash2Icon className="size-5" />
+              </AlertDialog.Icon>
+              <AlertDialog.Heading>Delete device permanently?</AlertDialog.Heading>
+            </AlertDialog.Header>
+            <AlertDialog.Body>
+              <p>
+                This will permanently delete <strong>{deviceName}</strong> and all of its data. This action cannot be
+                undone.
+              </p>
+            </AlertDialog.Body>
+            <AlertDialog.Footer>
+              <Button type="button" slot="close" variant="secondary">
+                Cancel
+              </Button>
+              <Form onSubmit={(e) => e.preventDefault()}>
+                <Button type="submit" variant="danger">
+                  Delete
+                </Button>
+              </Form>
+            </AlertDialog.Footer>
+          </AlertDialog.Dialog>
+        </AlertDialog.Container>
+      </AlertDialog.Backdrop>
+    </AlertDialog>
+  );
+}

--- a/src/features/device/components/delete-device-modal.tsx
+++ b/src/features/device/components/delete-device-modal.tsx
@@ -4,14 +4,17 @@ import { useActionState } from "react";
 
 import { Trash2Icon } from "lucide-react";
 
-import { AlertDialog, Button, ErrorMessage, Form } from "@heroui/react";
+import { AlertDialog, Button, ErrorMessage, Form, toast } from "@heroui/react";
 
-import { deleteDevice, useFormSuccess, type DeleteDeviceModalProps } from "@/features/device";
+import { ACTION_MESSAGE, deleteDevice, useFormSuccess, type DeleteDeviceModalProps } from "@/features/device";
 
 export default function DeleteDeviceModal({ deviceId, deviceName, onClose }: DeleteDeviceModalProps) {
   const [state, formAction, isFormLoading] = useActionState(deleteDevice.bind(null, deviceId), undefined);
 
-  useFormSuccess(state?.success, onClose);
+  useFormSuccess(state?.success, () => {
+    onClose();
+    toast.success(ACTION_MESSAGE.deleted);
+  });
 
   return (
     <AlertDialog isOpen onOpenChange={onClose}>

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -91,7 +91,9 @@ export default function DeviceActions({ device }: { device: Device }) {
 
       {modal === "share" && <ShareDeviceModal deviceId={device.id} onClose={() => setModal(null)} />}
 
-      {modal === "delete" && <DeleteDeviceModal deviceName={device.name} onClose={() => setModal(null)} />}
+      {modal === "delete" && (
+        <DeleteDeviceModal deviceId={device.id} deviceName={device.name} onClose={() => setModal(null)} />
+      )}
     </>
   );
 }

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -14,7 +14,14 @@ import {
   Trash2Icon,
 } from "lucide-react";
 
-import { type Device, EditDeviceModal, MoveDeviceModal, ShareDeviceModal, useCopyToClipboard } from "@/features/device";
+import {
+  DeleteDeviceModal,
+  type Device,
+  EditDeviceModal,
+  MoveDeviceModal,
+  ShareDeviceModal,
+  useCopyToClipboard,
+} from "@/features/device";
 
 export default function DeviceActions({ device }: { device: Device }) {
   const { copy } = useCopyToClipboard();
@@ -83,6 +90,8 @@ export default function DeviceActions({ device }: { device: Device }) {
       )}
 
       {modal === "share" && <ShareDeviceModal deviceId={device.id} onClose={() => setModal(null)} />}
+
+      {modal === "delete" && <DeleteDeviceModal deviceName={device.name} onClose={() => setModal(null)} />}
     </>
   );
 }

--- a/src/features/device/index.ts
+++ b/src/features/device/index.ts
@@ -40,4 +40,6 @@ export { default as MoveDeviceModal } from "./components/move-device-modal";
 
 export { default as ShareDeviceModal } from "./components/share-device-modal";
 
+export { default as DeleteDeviceModal } from "./components/delete-device-modal";
+
 export { default as FieldErrorMessage } from "./components/field-error-message";

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -12,7 +12,7 @@ import { getSession } from "@/dal/session";
 
 import { devicesTable } from "@/db/schemas";
 
-import { DeleteDeviceSchema, EditDeviceSchema, MoveDeviceSchema } from "@/features/device";
+import { type DeleteDeviceAction, DeleteDeviceSchema, EditDeviceSchema, MoveDeviceSchema } from "@/features/device";
 
 type PreviousState = {
   success: boolean;
@@ -133,9 +133,7 @@ export const moveDevice = async (
   };
 };
 
-type DeleteDevicePrevState = { success: boolean; serverError?: string };
-
-export const deleteDevice = async (deviceId: string): Promise<DeleteDevicePrevState> => {
+export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
   try {
     const { userId } = await getSession();
 

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -2,7 +2,7 @@
 
 import { z } from "zod";
 
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { revalidatePath } from "next/cache";
 
@@ -12,7 +12,7 @@ import { getSession } from "@/dal/session";
 
 import { devicesTable } from "@/db/schemas";
 
-import { EditDeviceSchema, MoveDeviceSchema } from "@/features/device";
+import { DeleteDeviceSchema, EditDeviceSchema, MoveDeviceSchema } from "@/features/device";
 
 type PreviousState = {
   success: boolean;
@@ -123,6 +123,38 @@ export const moveDevice = async (
       serverErrors: {
         group: "A server error has occurred.",
       },
+    };
+  }
+
+  revalidatePath("/dashboard");
+
+  return {
+    success: true,
+  };
+};
+
+type DeleteDevicePrevState = { success: boolean; serverError?: string };
+
+export const deleteDevice = async (deviceId: string): Promise<DeleteDevicePrevState> => {
+  try {
+    const { userId } = await getSession();
+
+    const parsedDeviceId = DeleteDeviceSchema.safeParse(deviceId);
+
+    if (!parsedDeviceId.success) {
+      return {
+        success: false,
+        serverError: "Failed to delete device.",
+      };
+    }
+
+    await db.transaction(async (tx) => {
+      await tx.delete(devicesTable).where(and(eq(devicesTable.id, deviceId), eq(devicesTable.userId, userId)));
+    });
+  } catch {
+    return {
+      success: false,
+      serverError: "A server error has occurred.",
     };
   }
 

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -1,3 +1,10 @@
 export const TABLE_COLUMNS = ["Name", "Type", "Status", "Group", "Serial Number", "Actions"];
 
 export const FORM_ID = "device-form";
+
+export const ACTION_MESSAGE = {
+  created: null,
+  updated: null,
+  moved: null,
+  deleted: "The device was successfully deleted.",
+};

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -12,4 +12,4 @@ export type MoveDeviceModalProps = { deviceId: string; deviceGroup: string; onCl
 
 export type ShareDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose">;
 
-export type DeleteDeviceModalProps = Pick<EditDeviceModalProps, "onClose"> & { deviceName: string };
+export type DeleteDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose"> & { deviceName: string };

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -11,3 +11,5 @@ export type EditDeviceModalProps = { device: Device; onClose: () => void };
 export type MoveDeviceModalProps = { deviceId: string; deviceGroup: string; onClose: () => void };
 
 export type ShareDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose">;
+
+export type DeleteDeviceModalProps = Pick<EditDeviceModalProps, "onClose"> & { deviceName: string };

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -1,5 +1,7 @@
 import { devicesTable } from "@/db/schemas";
 
+import type { ActionReturnType } from "@/lib/definitions";
+
 export type Device = Pick<typeof devicesTable.$inferSelect, "id" | "name" | "serialNumber" | "ipAddress"> & {
   type: string;
   status: string;
@@ -13,3 +15,5 @@ export type MoveDeviceModalProps = { deviceId: string; deviceGroup: string; onCl
 export type ShareDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose">;
 
 export type DeleteDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose"> & { deviceName: string };
+
+export type DeleteDeviceAction = ActionReturnType<{ serverError?: string }>;

--- a/src/features/device/lib/schemas.ts
+++ b/src/features/device/lib/schemas.ts
@@ -12,3 +12,5 @@ export const EditDeviceSchema = z.object({
 export const MoveDeviceSchema = EditDeviceSchema.pick({
   groupId: true,
 });
+
+export const DeleteDeviceSchema = z.string();

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -1,1 +1,3 @@
 export type ActionResult<T> = { data: T; error: null } | { data: null; error: string };
+
+export type ActionReturnType<T> = Promise<{ success: boolean } & T>;


### PR DESCRIPTION
This PR allows users to delete devices.

## Changes
- Built modal component that allows users to delete a device.
- Built the server action that handles the deletion of devices.
- Implemented a toast notification that will be shown when a device record is deleted.
- Created the constant `ACTION_MESSAGE`. This will be used to show messages upon a device action.
- Created the constants `ActionReturnType` and `DeleteDeviceAction`.