### PR TITLE
Feature/device actions refactor

### DIFF
--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { Button, Dropdown, type Key, Label, Separator, toast } from "@heroui/react";
 
@@ -38,12 +38,10 @@ export default function DeviceActions({ device }: { device: Device }) {
     }
   };
 
-  useEffect(() => {
-    if (modal === "view") {
-      // Will need to change the URL in the future.
-      window.open("#", "_blank");
-    }
-  }, [modal]);
+  const viewDeviceInNewTab = () => {
+    // Will need to change the URL in the future.
+    window.open("#", "_blank");
+  };
 
   return (
     <>
@@ -53,7 +51,7 @@ export default function DeviceActions({ device }: { device: Device }) {
         </Button>
         <Dropdown.Popover placement="bottom right">
           <Dropdown.Menu onAction={(key) => setModal(key)}>
-            <Dropdown.Item id="view" textValue="View">
+            <Dropdown.Item id="view" textValue="View" onAction={viewDeviceInNewTab}>
               <SquareArrowUpRightIcon className="text-muted size-4" />
               <Label>View</Label>
             </Dropdown.Item>

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 
 import {
+  ACTION_MESSAGE,
   DeleteDeviceModal,
   type Device,
   EditDeviceModal,
@@ -31,7 +32,7 @@ export default function DeviceActions({ device }: { device: Device }) {
   const copyDeviceId = async () => {
     try {
       await copy(device.id);
-      toast.success("Device ID copied to clipboard.");
+      toast.success(ACTION_MESSAGE.copied);
     } catch {
       toast.danger("Failed to copy device ID.");
     }

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -4,9 +4,10 @@ import { useActionState, useEffect } from "react";
 
 import { FolderClosedIcon } from "lucide-react";
 
-import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField } from "@heroui/react";
+import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField, toast } from "@heroui/react";
 
 import {
+  ACTION_MESSAGE,
   type EditDeviceModalProps,
   FieldErrorMessage,
   FORM_ID,
@@ -37,7 +38,10 @@ export default function EditDeviceModal({ device, onClose }: EditDeviceModalProp
 
   const [state, formAction, isFormLoading] = useActionState(updateDevice.bind(null, device.id), undefined);
 
-  useFormSuccess(state?.success, onClose);
+  useFormSuccess(state?.success, () => {
+    onClose();
+    toast.success(ACTION_MESSAGE.updated);
+  });
 
   useEffect(() => {
     if (selectedTypeId) handleFieldChange("type", selectedTypeId);

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -4,9 +4,10 @@ import { useActionState, useEffect } from "react";
 
 import { FolderClosedIcon } from "lucide-react";
 
-import { Button, Form, Label, ListBox, Modal, Select, Surface } from "@heroui/react";
+import { Button, Form, Label, ListBox, Modal, Select, Surface, toast } from "@heroui/react";
 
 import {
+  ACTION_MESSAGE,
   FieldErrorMessage,
   FORM_ID,
   generateId,
@@ -26,7 +27,10 @@ export default function MoveDeviceModal({ deviceId, deviceGroup, onClose }: Move
 
   const [state, formAction, isFormLoading] = useActionState(moveDevice.bind(null, deviceId), undefined);
 
-  useFormSuccess(state?.success, onClose);
+  useFormSuccess(state?.success, () => {
+    onClose();
+    toast.success(ACTION_MESSAGE.moved);
+  });
 
   useEffect(() => {
     if (selectedGroupId) handleFieldChange("group", selectedGroupId);

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -12,21 +12,15 @@ import { getSession } from "@/dal/session";
 
 import { devicesTable } from "@/db/schemas";
 
-import { type DeleteDeviceAction, DeleteDeviceSchema, EditDeviceSchema, MoveDeviceSchema } from "@/features/device";
+import {
+  type DeleteDeviceAction,
+  DeleteDeviceSchema,
+  EditDeviceAction,
+  EditDeviceSchema,
+  MoveDeviceSchema,
+} from "@/features/device";
 
-type PreviousState = {
-  success: boolean;
-  serverErrors?: Partial<{
-    name: string;
-    type: string;
-    status: string;
-    group: string;
-    ipAddress: string;
-    serialNumber: string;
-  }>;
-};
-
-export const updateDevice = async (deviceId: string, _previousState: PreviousState | undefined, formData: FormData) => {
+export const updateDevice = async (deviceId: string, _prevState: unknown, formData: FormData): EditDeviceAction => {
   const { userId } = await getSession();
 
   const parsedFields = EditDeviceSchema.safeParse({

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -15,8 +15,9 @@ import { devicesTable } from "@/db/schemas";
 import {
   type DeleteDeviceAction,
   DeleteDeviceSchema,
-  EditDeviceAction,
+  type EditDeviceAction,
   EditDeviceSchema,
+  type MoveDeviceAction,
   MoveDeviceSchema,
 } from "@/features/device";
 
@@ -78,13 +79,7 @@ export const updateDevice = async (deviceId: string, _prevState: unknown, formDa
   };
 };
 
-type MoveDevicePrevState = { success: boolean; serverErrors?: Partial<{ group: string }> };
-
-export const moveDevice = async (
-  deviceId: string,
-  _previousState: MoveDevicePrevState | undefined,
-  formData: FormData,
-) => {
+export const moveDevice = async (deviceId: string, _prevState: unknown, formData: FormData): MoveDeviceAction => {
   try {
     const { userId } = await getSession();
 

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -7,4 +7,5 @@ export const ACTION_MESSAGE = {
   updated: "The device was successfully updated.",
   moved: "The device was successfully moved.",
   deleted: "The device was successfully deleted.",
+  copied: "The device ID was successfully copied to the clipboard.",
 };

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -5,6 +5,6 @@ export const FORM_ID = "device-form";
 export const ACTION_MESSAGE = {
   created: null,
   updated: "The device was successfully updated.",
-  moved: null,
+  moved: "The device was successfully moved.",
   deleted: "The device was successfully deleted.",
 };

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -4,7 +4,7 @@ export const FORM_ID = "device-form";
 
 export const ACTION_MESSAGE = {
   created: null,
-  updated: null,
+  updated: "The device was successfully updated.",
   moved: null,
   deleted: "The device was successfully deleted.",
 };

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -28,3 +28,5 @@ export type EditDeviceAction = ActionReturnType<{
     serialNumber: string;
   }>;
 }>;
+
+export type MoveDeviceAction = ActionReturnType<{ serverErrors?: Partial<{ group: string }> }>;

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -17,3 +17,14 @@ export type ShareDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onC
 export type DeleteDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose"> & { deviceName: string };
 
 export type DeleteDeviceAction = ActionReturnType<{ serverError?: string }>;
+
+export type EditDeviceAction = ActionReturnType<{
+  serverErrors?: Partial<{
+    name: string;
+    type: string;
+    status: string;
+    group: string;
+    ipAddress: string;
+    serialNumber: string;
+  }>;
+}>;


### PR DESCRIPTION
This PR improves the device server actions. I've also provided feedback based on the action taken.

## Changes
- Show message when a device was edited.
- Show message when a device was moved.
- Moved the copy to clipboard message to the `ACTION_MESSAGE` constant.
- Created the function `viewDeviceInNewTab` to handle the logic in viewing the device a new tab.
- Removed the `useEffect` from the device actions component.
- Added return types for each device action via the server actions file.