### PR TITLE
Refactor/cleanup types

### DIFF
--- a/src/features/auth/components/login-form.tsx
+++ b/src/features/auth/components/login-form.tsx
@@ -26,7 +26,7 @@ export default function LoginForm() {
           value={userEmail}
           onChange={(e) => setUserEmail(e.target.value)}
         />
-        {state?.serverErrors.email && !loading ? (
+        {state?.serverErrors?.email && !loading ? (
           <p aria-live="polite" className="text-danger px-1 text-xs">
             {state.serverErrors.email}
           </p>
@@ -43,7 +43,7 @@ export default function LoginForm() {
           value={userPassword}
           onChange={(e) => setUserPassword(e.target.value)}
         />
-        {state?.serverErrors.password && !loading ? (
+        {state?.serverErrors?.password && !loading ? (
           <p aria-live="polite" className="text-danger px-1 text-xs">
             {state.serverErrors.password}
           </p>

--- a/src/features/auth/lib/actions.ts
+++ b/src/features/auth/lib/actions.ts
@@ -10,14 +10,7 @@ import { auth } from "@/lib/auth";
 
 import { LoginFormSchema } from "@/features/auth/lib/schemas";
 
-type PreviousState = {
-  serverErrors?: {
-    email?: string;
-    password?: string;
-  };
-};
-
-export const authenticateUser = async (_previousState: PreviousState | undefined, formData: FormData) => {
+export const authenticateUser = async (_prevState: unknown, formData: FormData) => {
   const parsedFields = LoginFormSchema.safeParse({
     email: formData.get("email"),
     password: formData.get("password"),

--- a/src/features/auth/lib/actions.ts
+++ b/src/features/auth/lib/actions.ts
@@ -8,9 +8,13 @@ import { APIError, isAPIError } from "better-auth/api";
 
 import { auth } from "@/lib/auth";
 
+import type { ActionReturnType } from "@/lib/definitions";
+
 import { LoginFormSchema } from "@/features/auth/lib/schemas";
 
-export const authenticateUser = async (_prevState: unknown, formData: FormData) => {
+type AuthenticateUserReturnType = ActionReturnType<Partial<{ email: string; password: string }>>;
+
+export const authenticateUser = async (_prevState: unknown, formData: FormData): AuthenticateUserReturnType => {
   const parsedFields = LoginFormSchema.safeParse({
     email: formData.get("email"),
     password: formData.get("password"),
@@ -21,6 +25,7 @@ export const authenticateUser = async (_prevState: unknown, formData: FormData) 
       const { fieldErrors } = z.flattenError(parsedFields.error);
 
       return {
+        success: false,
         serverErrors: {
           email: fieldErrors.email?.toString(),
           password: fieldErrors.password?.toString(),
@@ -46,6 +51,7 @@ export const authenticateUser = async (_prevState: unknown, formData: FormData) 
     if (isAPIError(error)) {
       if (error.body?.code === auth.$ERROR_CODES.INVALID_EMAIL_OR_PASSWORD.code) {
         return {
+          success: false,
           serverErrors: {
             password: `${error.message}.`,
           },
@@ -54,6 +60,7 @@ export const authenticateUser = async (_prevState: unknown, formData: FormData) 
     }
 
     return {
+      success: false,
       serverErrors: {
         password: "A server error has occurred.",
       },

--- a/src/features/dashboard/components/nav-list.tsx
+++ b/src/features/dashboard/components/nav-list.tsx
@@ -8,9 +8,11 @@ import { listboxItemVariants, listboxVariants } from "@heroui/react";
 
 import { getNavIcon } from "@/features/dashboard/lib/utils";
 
-import { type NavItem } from "@/features/dashboard/lib/definitions";
+import type { NavItem } from "@/features/dashboard/lib/definitions";
 
-export default function NavList({ items }: { items: NavItem[] }) {
+type NavListProps = { items: NavItem[] };
+
+export default function NavList({ items }: NavListProps) {
   const pathname = usePathname();
 
   return (

--- a/src/features/dashboard/lib/definitions.ts
+++ b/src/features/dashboard/lib/definitions.ts
@@ -1,5 +1,7 @@
 export type NavItem = {
   id: string;
-  label: "dashboard" | "devices" | "profile";
+  label: NavItemLabel;
   href: string;
 };
+
+export type NavItemLabel = "dashboard" | "devices" | "profile";

--- a/src/features/dashboard/lib/utils.ts
+++ b/src/features/dashboard/lib/utils.ts
@@ -1,8 +1,8 @@
 import { HouseIcon, MonitorSmartphoneIcon, UserRoundIcon } from "lucide-react";
 
-import type { NavItem } from "@/features/dashboard/lib/definitions";
+import type { NavItemLabel } from "@/features/dashboard/lib/definitions";
 
-export const getNavIcon = (label: NavItem["label"]) => {
+export const getNavIcon = (label: NavItemLabel) => {
   switch (label) {
     case "dashboard":
       return HouseIcon;

--- a/src/features/device/components/delete-device-modal.tsx
+++ b/src/features/device/components/delete-device-modal.tsx
@@ -10,9 +10,11 @@ import { deleteDevice } from "@/features/device/lib/actions";
 
 import { ACTION_MESSAGE } from "@/features/device/lib/constants";
 
-import type { DeleteDeviceModalProps } from "@/features/device/lib/definitions";
+import type { BaseDeviceModalProps } from "@/features/device/lib/definitions";
 
 import useFormSuccess from "@/features/device/hooks/use-form-success";
+
+type DeleteDeviceModalProps = BaseDeviceModalProps & { deviceName: string };
 
 export default function DeleteDeviceModal({ deviceId, deviceName, onClose }: DeleteDeviceModalProps) {
   const [state, formAction, isFormLoading] = useActionState(deleteDevice.bind(null, deviceId), undefined);

--- a/src/features/device/components/delete-device-modal.tsx
+++ b/src/features/device/components/delete-device-modal.tsx
@@ -41,7 +41,7 @@ export default function DeleteDeviceModal({ deviceId, deviceName, onClose }: Del
               <p>
                 This will permanently delete <strong>{deviceName}</strong>. This action cannot be undone.
               </p>
-              {state?.serverError && <ErrorMessage>{state.serverError}</ErrorMessage>}
+              {state?.serverErrors?.message && <ErrorMessage>{state.serverErrors.message}</ErrorMessage>}
             </AlertDialog.Body>
             <AlertDialog.Footer>
               <Button type="button" slot="close" variant="secondary">

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -28,17 +28,14 @@ import ShareDeviceModal from "@/features/device/components/share-device-modal";
 
 import DeleteDeviceModal from "@/features/device/components/delete-device-modal";
 
-export default function DeviceActions({
-  device,
-  types,
-  statuses,
-  groups,
-}: {
+type DeviceActionsProps = {
   device: Device;
   types: DeviceType[] | null;
   statuses: DeviceStatus[] | null;
   groups: DeviceGroup[] | null;
-}) {
+};
+
+export default function DeviceActions({ device, types, statuses, groups }: DeviceActionsProps) {
   const { copy } = useCopyToClipboard();
 
   const [modal, setModal] = useState<Key | null>(null);

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -8,17 +8,25 @@ import { Button, Form, Input, Label, ListBox, Modal, Select, Surface, TextField,
 
 import { ACTION_MESSAGE, FORM_ID } from "@/features/device/lib/constants";
 
-import type { EditDeviceModalProps } from "@/features/device/lib/definitions";
-
 import { generateDeviceFieldIds, generateId } from "@/features/device/lib/utils";
 
 import { updateDevice } from "@/features/device/lib/actions";
+
+import type { Device, DeviceGroup, DeviceStatus, DeviceType } from "@/features/device/lib/definitions";
 
 import useFields from "@/features/device/hooks/use-fields";
 
 import useFormSuccess from "@/features/device/hooks/use-form-success";
 
 import FieldErrorMessage from "@/features/device/components/field-error-message";
+
+type EditDeviceModalProps = {
+  device: Device;
+  types: DeviceType[] | null;
+  statuses: DeviceStatus[] | null;
+  groups: DeviceGroup[] | null;
+  onClose: () => void;
+};
 
 export default function EditDeviceModal({ device, types, statuses, groups, onClose }: EditDeviceModalProps) {
   const isTypesEmpty = types?.length === 0;

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -12,13 +12,15 @@ import { moveDevice } from "@/features/device/lib/actions";
 
 import { ACTION_MESSAGE, FORM_ID } from "@/features/device/lib/constants";
 
-import type { MoveDeviceModalProps } from "@/features/device/lib/definitions";
+import type { BaseDeviceModalProps, DeviceGroup } from "@/features/device/lib/definitions";
 
 import useFields from "@/features/device/hooks/use-fields";
 
 import useFormSuccess from "@/features/device/hooks/use-form-success";
 
 import FieldErrorMessage from "@/features/device/components/field-error-message";
+
+type MoveDeviceModalProps = BaseDeviceModalProps<{ deviceGroup: string; groups: DeviceGroup[] | null }>;
 
 export default function MoveDeviceModal({ deviceId, deviceGroup, groups, onClose }: MoveDeviceModalProps) {
   const isGroupsEmpty = groups?.length === 0;

--- a/src/features/device/components/share-device-modal.tsx
+++ b/src/features/device/components/share-device-modal.tsx
@@ -4,7 +4,7 @@ import { CheckIcon, CopyIcon, Share2Icon } from "lucide-react";
 
 import { Button, InputGroup, Label, Modal, Surface, TextField } from "@heroui/react";
 
-import type { ShareDeviceModalProps } from "@/features/device/lib/definitions";
+import type { BaseDeviceModalProps } from "@/features/device/lib/definitions";
 
 import useTimer from "@/features/dashboard/hooks/use-timer";
 
@@ -14,6 +14,8 @@ const getUrlProtocolAndDomain = () => {
   const { protocol, host } = window.location;
   return `${protocol}//${host}`;
 };
+
+type ShareDeviceModalProps = BaseDeviceModalProps;
 
 export default function ShareDeviceModal({ deviceId, onClose }: ShareDeviceModalProps) {
   const { copy } = useCopyToClipboard();

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -16,15 +16,6 @@ import { DeleteDeviceSchema, EditDeviceSchema, MoveDeviceSchema } from "@/featur
 
 import type { DeleteDeviceAction, EditDeviceAction, MoveDeviceAction } from "@/features/device/lib/definitions";
 
-// import {
-//   type DeleteDeviceAction,
-//   DeleteDeviceSchema,
-//   type EditDeviceAction,
-//   EditDeviceSchema,
-//   type MoveDeviceAction,
-//   MoveDeviceSchema,
-// } from "@/features/device";
-
 export const updateDevice = async (deviceId: string, _prevState: unknown, formData: FormData): EditDeviceAction => {
   const { userId } = await getSession();
 

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -14,18 +14,11 @@ import { devicesTable } from "@/db/schemas";
 
 import type { ActionReturnType } from "@/lib/definitions";
 
+import type { Device } from "@/features/device/lib/definitions";
+
 import { DeleteDeviceSchema, EditDeviceSchema, MoveDeviceSchema } from "@/features/device/lib/schemas";
 
-type EditDeviceAction = ActionReturnType<
-  Partial<{
-    name: string;
-    type: string;
-    status: string;
-    group: string;
-    ipAddress: string;
-    serialNumber: string;
-  }>
->;
+type EditDeviceAction = ActionReturnType<Partial<Omit<Device, "id">> & { ipAddress?: string }>;
 
 export const updateDevice = async (deviceId: string, _prevState: unknown, formData: FormData): EditDeviceAction => {
   const { userId } = await getSession();

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -12,9 +12,20 @@ import { getSession } from "@/dal/session";
 
 import { devicesTable } from "@/db/schemas";
 
+import type { ActionReturnType } from "@/lib/definitions";
+
 import { DeleteDeviceSchema, EditDeviceSchema, MoveDeviceSchema } from "@/features/device/lib/schemas";
 
-import type { DeleteDeviceAction, EditDeviceAction, MoveDeviceAction } from "@/features/device/lib/definitions";
+type EditDeviceAction = ActionReturnType<
+  Partial<{
+    name: string;
+    type: string;
+    status: string;
+    group: string;
+    ipAddress: string;
+    serialNumber: string;
+  }>
+>;
 
 export const updateDevice = async (deviceId: string, _prevState: unknown, formData: FormData): EditDeviceAction => {
   const { userId } = await getSession();
@@ -75,6 +86,8 @@ export const updateDevice = async (deviceId: string, _prevState: unknown, formDa
   };
 };
 
+type MoveDeviceAction = ActionReturnType<Partial<{ group: string }>>;
+
 export const moveDevice = async (deviceId: string, _prevState: unknown, formData: FormData): MoveDeviceAction => {
   try {
     const { userId } = await getSession();
@@ -118,6 +131,8 @@ export const moveDevice = async (deviceId: string, _prevState: unknown, formData
     serverErrors: null,
   };
 };
+
+type DeleteDeviceAction = ActionReturnType<{ message: string }>;
 
 export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
   try {

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -80,6 +80,7 @@ export const updateDevice = async (deviceId: string, _prevState: unknown, formDa
 
   return {
     success: true,
+    serverErrors: null,
   };
 };
 
@@ -123,6 +124,7 @@ export const moveDevice = async (deviceId: string, _prevState: unknown, formData
 
   return {
     success: true,
+    serverErrors: null,
   };
 };
 
@@ -135,7 +137,9 @@ export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
     if (!parsedDeviceId.success) {
       return {
         success: false,
-        serverError: "Failed to delete device.",
+        serverErrors: {
+          message: "Failed to delete device.",
+        },
       };
     }
 
@@ -145,7 +149,9 @@ export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
   } catch {
     return {
       success: false,
-      serverError: "A server error has occurred.",
+      serverErrors: {
+        message: "A server error has occurred.",
+      },
     };
   }
 
@@ -153,5 +159,6 @@ export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
 
   return {
     success: true,
+    serverErrors: null,
   };
 };

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -16,14 +16,6 @@ export type DeviceStatus = DeviceIdAndName;
 
 export type DeviceGroup = DeviceIdAndName;
 
-export type EditDeviceModalProps = {
-  device: Device;
-  types: DeviceType[] | null;
-  statuses: DeviceStatus[] | null;
-  groups: DeviceGroup[] | null;
-  onClose: () => void;
-};
-
 export type MoveDeviceModalProps = {
   deviceId: string;
   deviceGroup: string;

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -8,15 +8,17 @@ export type Device = Pick<typeof devicesTable.$inferSelect, "id" | "name" | "ser
   group: string;
 };
 
-export type DeviceType = Pick<Device, "id" | "name">;
+type DeviceIdAndName = Pick<Device, "id" | "name">;
 
-export type DeviceStatus = Pick<Device, "id" | "name">;
+export type DeviceType = DeviceIdAndName;
 
-export type DeviceGroup = Pick<Device, "id" | "name">;
+export type DeviceStatus = DeviceIdAndName;
+
+export type DeviceGroup = DeviceIdAndName;
 
 export type EditDeviceModalProps = {
   device: Device;
-  types: { id: string; name: string }[] | null;
+  types: DeviceType[] | null;
   statuses: DeviceStatus[] | null;
   groups: DeviceGroup[] | null;
   onClose: () => void;

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -16,16 +16,10 @@ export type DeviceStatus = DeviceIdAndName;
 
 export type DeviceGroup = DeviceIdAndName;
 
-export type MoveDeviceModalProps = {
+export type BaseDeviceModalProps<T = object> = {
   deviceId: string;
-  deviceGroup: string;
-  groups: DeviceGroup[] | null;
   onClose: () => void;
-};
-
-export type ShareDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose">;
-
-export type DeleteDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose"> & { deviceName: string };
+} & T;
 
 export type DeleteDeviceAction = ActionReturnType<{ message: string }>;
 

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -33,17 +33,17 @@ export type ShareDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onC
 
 export type DeleteDeviceModalProps = Pick<MoveDeviceModalProps, "deviceId" | "onClose"> & { deviceName: string };
 
-export type DeleteDeviceAction = ActionReturnType<{ serverError?: string }>;
+export type DeleteDeviceAction = ActionReturnType<{ message: string }>;
 
-export type EditDeviceAction = ActionReturnType<{
-  serverErrors?: Partial<{
+export type EditDeviceAction = ActionReturnType<
+  Partial<{
     name: string;
     type: string;
     status: string;
     group: string;
     ipAddress: string;
     serialNumber: string;
-  }>;
-}>;
+  }>
+>;
 
-export type MoveDeviceAction = ActionReturnType<{ serverErrors?: Partial<{ group: string }> }>;
+export type MoveDeviceAction = ActionReturnType<Partial<{ group: string }>>;

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -1,7 +1,5 @@
 import { devicesTable } from "@/db/schemas";
 
-import type { ActionReturnType } from "@/lib/definitions";
-
 export type Device = Pick<typeof devicesTable.$inferSelect, "id" | "name" | "serialNumber" | "ipAddress"> & {
   type: string;
   status: string;
@@ -20,18 +18,3 @@ export type BaseDeviceModalProps<T = object> = {
   deviceId: string;
   onClose: () => void;
 } & T;
-
-export type DeleteDeviceAction = ActionReturnType<{ message: string }>;
-
-export type EditDeviceAction = ActionReturnType<
-  Partial<{
-    name: string;
-    type: string;
-    status: string;
-    group: string;
-    ipAddress: string;
-    serialNumber: string;
-  }>
->;
-
-export type MoveDeviceAction = ActionReturnType<Partial<{ group: string }>>;

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -1,3 +1,3 @@
 export type ActionResult<T> = { data: T; error: null } | { data: null; error: string };
 
-export type ActionReturnType<T> = Promise<{ success: boolean } & T>;
+export type ActionReturnType<T extends object> = Promise<{ success: boolean; serverErrors: T | null }>;


### PR DESCRIPTION
This PR improves upon the TypeScript types implemented.

## Changes
- `_prevState` has been set to `unknown` for the `authenticateUser` function.
- Created a separate `NavItemLabel` type for the nav items.
- Created `BaseDeviceModalProps` type.
- Created `DeviceActionsProps` type.
- Each device action is typed.