### PR TITLE
Fix/controlled forms

### DIFF
--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -10,6 +10,8 @@ import { updateDevice } from "@/features/device/lib/actions";
 
 import type { Device, DeviceGroup, DeviceStatus, DeviceType } from "@/features/device/lib/definitions";
 
+import useFields from "@/features/device/hooks/use-fields";
+
 import useFormSuccess from "@/features/device/hooks/use-form-success";
 
 import { Input } from "@/components/ui/input";
@@ -37,6 +39,15 @@ export default function EditDeviceModal({ device, types, statuses, groups, onClo
 
   const isGroupsEmpty = !groups || groups?.length === 0;
 
+  const { field, handleFieldChange } = useFields({
+    name: device.name,
+    typeId: device.typeId,
+    statusId: device.statusId,
+    groupId: device.groupId,
+    serialNumber: device.serialNumber,
+    ipAddress: device.ipAddress,
+  });
+
   const [state, formAction, isFormLoading] = useActionState(updateDevice.bind(null, device.id), undefined);
 
   const closeModalAndShowToast = () => {
@@ -62,7 +73,8 @@ export default function EditDeviceModal({ device, types, statuses, groups, onClo
                 name="name"
                 placeholder="John's MacBook Pro"
                 autoComplete="off"
-                defaultValue={device.name}
+                value={field.name}
+                onChange={(e) => handleFieldChange("name", e.target.value)}
                 required
               />
               <FieldError>{state?.serverErrors?.name}</FieldError>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -176,7 +176,8 @@ export default function EditDeviceModal({ device, types, statuses, groups, onClo
                 type="text"
                 name="ip-address"
                 placeholder="192.168.1.1"
-                defaultValue={device.ipAddress ?? ""}
+                value={field.ipAddress ?? ""}
+                onChange={(e) => handleFieldChange("ipAddress", e.target.value)}
                 autoComplete="off"
               />
               <FieldError>{state?.serverErrors?.ipAddress}</FieldError>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -135,7 +135,8 @@ export default function EditDeviceModal({ device, types, statuses, groups, onClo
                 id="group"
                 name="group"
                 items={groups?.map((group) => ({ label: group.name, value: group.id }))}
-                defaultValue={isGroupsEmpty ? null : device.groupId}
+                value={isGroupsEmpty ? null : field.groupId}
+                onValueChange={(e) => handleFieldChange("groupId", e)}
                 disabled={isGroupsEmpty}
                 required
               >

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -85,7 +85,8 @@ export default function EditDeviceModal({ device, types, statuses, groups, onClo
                 id="type"
                 name="type"
                 items={types?.map((type) => ({ label: type.name, value: type.id }))}
-                defaultValue={isTypesEmpty ? null : device.typeId}
+                value={isTypesEmpty ? null : field.typeId}
+                onValueChange={(e) => handleFieldChange("typeId", e)}
                 disabled={isTypesEmpty}
               >
                 <SelectTrigger>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -163,7 +163,8 @@ export default function EditDeviceModal({ device, types, statuses, groups, onClo
                 name="serial-number"
                 placeholder="SN-LTP-1002"
                 autoComplete="off"
-                defaultValue={device.serialNumber}
+                value={field.serialNumber}
+                onChange={(e) => handleFieldChange("serialNumber", e.target.value)}
                 required
               />
               <FieldError>{state?.serverErrors?.serialNumber}</FieldError>

--- a/src/features/device/components/edit-device-modal.tsx
+++ b/src/features/device/components/edit-device-modal.tsx
@@ -110,7 +110,8 @@ export default function EditDeviceModal({ device, types, statuses, groups, onClo
                 id="status"
                 name="status"
                 items={statuses?.map((status) => ({ label: status.name, value: status.id }))}
-                defaultValue={isStatusesEmpty ? null : device.statusId}
+                value={isStatusesEmpty ? null : field.statusId}
+                onValueChange={(e) => handleFieldChange("statusId", e)}
                 disabled={isStatusesEmpty}
               >
                 <SelectTrigger>

--- a/src/features/device/components/move-device-modal.tsx
+++ b/src/features/device/components/move-device-modal.tsx
@@ -10,6 +10,8 @@ import { ACTION_MESSAGE, FORM_ID } from "@/features/device/lib/constants";
 
 import type { BaseDeviceModalProps, DeviceGroup } from "@/features/device/lib/definitions";
 
+import useFields from "@/features/device/hooks/use-fields";
+
 import useFormSuccess from "@/features/device/hooks/use-form-success";
 
 import { Button } from "@/components/ui/button";
@@ -27,6 +29,8 @@ type MoveDeviceModalProps = BaseDeviceModalProps<{
 
 export default function MoveDeviceModal({ deviceId, groupId, groups, onClose }: MoveDeviceModalProps) {
   const isGroupsEmpty = !groups || groups.length === 0;
+
+  const { field, handleFieldChange } = useFields({ groupId: groupId });
 
   const [state, formAction, isFormLoading] = useActionState(moveDevice.bind(null, deviceId), undefined);
 
@@ -50,7 +54,8 @@ export default function MoveDeviceModal({ deviceId, groupId, groups, onClose }: 
               id="group"
               name="group"
               items={groups?.map((group) => ({ label: group.name, value: group.id }))}
-              defaultValue={isGroupsEmpty ? null : groupId}
+              value={isGroupsEmpty ? null : field.groupId}
+              onValueChange={(value) => handleFieldChange("groupId", value ?? "")}
               required
               disabled={isGroupsEmpty}
             >

--- a/src/features/device/hooks/use-fields.tsx
+++ b/src/features/device/hooks/use-fields.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
-export default function useFields(initialState: Record<string, { name: string; value: string }>) {
+type UseFieldsProps<T> = { [K in keyof T]: T[K] };
+
+export default function useField<T>(initialState: UseFieldsProps<T>) {
   const [field, setField] = useState(initialState);
 
-  const handleFieldChange = useCallback((name: keyof typeof field, value: string) => {
-    setField((prevState) => ({ ...prevState, [name]: { name: prevState[name].name, value } }));
-  }, []);
+  const handleFieldChange = (name: keyof typeof field, value: T[keyof T]) => {
+    setField((prevState) => ({ ...prevState, [name]: value }));
+  };
 
   return {
     field,


### PR DESCRIPTION
This PR sets the form fields from an uncontrolled to a controlled state.

## Changes
- Refactored the`useField` hook.
- Updated the logic for the `name` field.
- Updated the logic for the `type` field.
- Updated the logic for the `status` field.
- Updated the logic for the `group` fields.
- Updated the logic for the `serial number` field.
- Updated the logic for the `ip address` field.