### PR TITLE
Feature/filter devices table data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "shadcn": "^4.5.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "use-debounce": "^10.1.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -12040,6 +12041,18 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.1.tgz",
+      "integrity": "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "shadcn": "^4.5.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "use-debounce": "^10.1.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import { getDeviceTypes } from "@/dal/type";
 
 import { getDeviceGroups } from "@/dal/group";
@@ -17,6 +19,8 @@ import DeviceSearchBar from "@/features/device/components/device-search-bar";
 import { Header, HeaderTitle } from "@/features/dashboard/components/header";
 
 import ClearFilterButton from "@/features/device/components/clear-filter-button";
+
+import FilterButtonSkeleton from "@/features/device/components/filter-button-skeleton";
 
 type DevicesPageProps = {
   searchParams: Promise<{
@@ -52,13 +56,19 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
             <DeviceSearchBar />
           </ButtonGroup>
           <ButtonGroup aria-label="Type Group">
-            <FilterPopover label="Type" items={typesPromise} />
+            <Suspense fallback={<FilterButtonSkeleton />}>
+              <FilterPopover label="Type" items={typesPromise} />
+            </Suspense>
           </ButtonGroup>
           <ButtonGroup aria-label="Status Group">
-            <FilterPopover label="Status" items={statusesPromise} />
+            <Suspense fallback={<FilterButtonSkeleton />}>
+              <FilterPopover label="Status" items={statusesPromise} />
+            </Suspense>
           </ButtonGroup>
           <ButtonGroup aria-label="Group Group">
-            <FilterPopover label="Group" items={groupsPromise} />
+            <Suspense fallback={<FilterButtonSkeleton />}>
+              <FilterPopover label="Group" items={groupsPromise} />
+            </Suspense>
           </ButtonGroup>
           <ButtonGroup>
             <ClearFilterButton />

--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -8,6 +8,8 @@ import { getDeviceStatuses } from "@/dal/status";
 
 import { ButtonGroup } from "@/components/ui/button-group";
 
+import SearchProvider from "@/features/device/providers/search-provider";
+
 import DeviceTable from "@/features/device/components/device-table";
 
 import ButtonActions from "@/features/device/components/button-actions";
@@ -50,38 +52,40 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
         <HeaderTitle>Devices</HeaderTitle>
       </Header>
       <main>
-        <div className="flex justify-end pb-5 lg:hidden">
-          <ButtonActions />
-        </div>
-        <ButtonGroup className="w-full sm:pb-5">
-          <ButtonGroup aria-label="Search Bar Group" className="hidden sm:flex">
+        <SearchProvider>
+          <div className="flex justify-end pb-5 lg:hidden">
+            <ButtonActions />
+          </div>
+          <ButtonGroup className="w-full sm:pb-5">
+            <ButtonGroup aria-label="Search Bar Group" className="hidden sm:flex">
+              <DeviceSearchBar />
+            </ButtonGroup>
+            <ButtonGroup aria-label="Type Group">
+              <Suspense fallback={<FilterButtonSkeleton />}>
+                <FilterPopover label="Type" items={typesPromise} />
+              </Suspense>
+            </ButtonGroup>
+            <ButtonGroup aria-label="Status Group">
+              <Suspense fallback={<FilterButtonSkeleton />}>
+                <FilterPopover label="Status" items={statusesPromise} />
+              </Suspense>
+            </ButtonGroup>
+            <ButtonGroup aria-label="Group Group">
+              <Suspense fallback={<FilterButtonSkeleton />}>
+                <FilterPopover label="Group" items={groupsPromise} />
+              </Suspense>
+            </ButtonGroup>
+            <ButtonGroup>
+              <ClearFilterButton />
+            </ButtonGroup>
+            <ButtonGroup className="hidden lg:flex lg:grow lg:justify-end">
+              <ButtonActions />
+            </ButtonGroup>
+          </ButtonGroup>
+          <ButtonGroup className="w-full pt-2 pb-5 sm:hidden">
             <DeviceSearchBar />
           </ButtonGroup>
-          <ButtonGroup aria-label="Type Group">
-            <Suspense fallback={<FilterButtonSkeleton />}>
-              <FilterPopover label="Type" items={typesPromise} />
-            </Suspense>
-          </ButtonGroup>
-          <ButtonGroup aria-label="Status Group">
-            <Suspense fallback={<FilterButtonSkeleton />}>
-              <FilterPopover label="Status" items={statusesPromise} />
-            </Suspense>
-          </ButtonGroup>
-          <ButtonGroup aria-label="Group Group">
-            <Suspense fallback={<FilterButtonSkeleton />}>
-              <FilterPopover label="Group" items={groupsPromise} />
-            </Suspense>
-          </ButtonGroup>
-          <ButtonGroup>
-            <ClearFilterButton />
-          </ButtonGroup>
-          <ButtonGroup className="hidden lg:flex lg:grow lg:justify-end">
-            <ButtonActions />
-          </ButtonGroup>
-        </ButtonGroup>
-        <ButtonGroup className="w-full pt-2 pb-5 sm:hidden">
-          <DeviceSearchBar />
-        </ButtonGroup>
+        </SearchProvider>
         <Suspense fallback={<DeviceTableSkeleton />}>
           <DeviceTable types={types} statuses={statuses} groups={groups} />
         </Suspense>

--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -32,12 +32,14 @@ type DevicesPageProps = {
     status?: string | string[];
     group?: string | string[];
     page?: string;
+    q?: string;
   }>;
 };
 
 export default async function DevicesPage({ searchParams }: DevicesPageProps) {
   const params = await searchParams;
 
+  const query = params.q ?? "";
   const types = params.type?.toString() ?? "";
   const statuses = params.status?.toString() ?? "";
   const groups = params.group?.toString() ?? "";
@@ -87,7 +89,7 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
           </ButtonGroup>
         </SearchProvider>
         <Suspense fallback={<DeviceTableSkeleton />}>
-          <DeviceTable types={types} statuses={statuses} groups={groups} />
+          <DeviceTable query={query} types={types} statuses={statuses} groups={groups} />
         </Suspense>
       </main>
     </>

--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -20,6 +20,8 @@ import { Header, HeaderTitle } from "@/features/dashboard/components/header";
 
 import ClearFilterButton from "@/features/device/components/clear-filter-button";
 
+import DeviceTableSkeleton from "@/features/device/components/device-table-skeleton";
+
 import FilterButtonSkeleton from "@/features/device/components/filter-button-skeleton";
 
 type DevicesPageProps = {
@@ -80,7 +82,9 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
         <ButtonGroup className="w-full pt-2 pb-5 sm:hidden">
           <DeviceSearchBar />
         </ButtonGroup>
-        <DeviceTable types={types} statuses={statuses} groups={groups} />
+        <Suspense fallback={<DeviceTableSkeleton />}>
+          <DeviceTable types={types} statuses={statuses} groups={groups} />
+        </Suspense>
       </main>
     </>
   );

--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -18,7 +18,22 @@ import { Header, HeaderTitle } from "@/features/dashboard/components/header";
 
 import ClearFilterButton from "@/features/device/components/clear-filter-button";
 
-export default function DevicesPage() {
+type DevicesPageProps = {
+  searchParams: Promise<{
+    type?: string;
+    status?: string;
+    group?: string;
+    page?: string;
+  }>;
+};
+
+export default async function DevicesPage({ searchParams }: DevicesPageProps) {
+  const params = await searchParams;
+
+  const types = params.type ?? "";
+  const statuses = params.status ?? "";
+  const groups = params.group ?? "";
+
   return (
     <>
       <Header>
@@ -51,7 +66,7 @@ export default function DevicesPage() {
         <ButtonGroup className="w-full pt-2 pb-5 sm:hidden">
           <DeviceSearchBar />
         </ButtonGroup>
-        <DeviceTable />
+        <DeviceTable types={types} statuses={statuses} groups={groups} />
       </main>
     </>
   );

--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -1,8 +1,8 @@
-import typesJson from "@/lib/data/device-types.json";
+import { getDeviceTypes } from "@/dal/type";
 
-import groupsJson from "@/lib/data/device-groups.json";
+import { getDeviceGroups } from "@/dal/group";
 
-import statusesJson from "@/lib/data/device-statuses.json";
+import { getDeviceStatuses } from "@/dal/status";
 
 import { ButtonGroup } from "@/components/ui/button-group";
 
@@ -34,6 +34,10 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
   const statuses = params.status ?? "";
   const groups = params.group ?? "";
 
+  const typesPromise = getDeviceTypes();
+  const statusesPromise = getDeviceStatuses();
+  const groupsPromise = getDeviceGroups();
+
   return (
     <>
       <Header>
@@ -48,13 +52,13 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
             <DeviceSearchBar />
           </ButtonGroup>
           <ButtonGroup aria-label="Type Group">
-            <FilterPopover label="Type" items={typesJson.map(({ name }) => name)} />
+            <FilterPopover label="Type" items={typesPromise} />
           </ButtonGroup>
           <ButtonGroup aria-label="Status Group">
-            <FilterPopover label="Status" items={statusesJson.map(({ name }) => name)} />
+            <FilterPopover label="Status" items={statusesPromise} />
           </ButtonGroup>
           <ButtonGroup aria-label="Group Group">
-            <FilterPopover label="Group" items={groupsJson.map(({ name }) => name)} />
+            <FilterPopover label="Group" items={groupsPromise} />
           </ButtonGroup>
           <ButtonGroup>
             <ClearFilterButton />

--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -20,9 +20,9 @@ import ClearFilterButton from "@/features/device/components/clear-filter-button"
 
 type DevicesPageProps = {
   searchParams: Promise<{
-    type?: string;
-    status?: string;
-    group?: string;
+    type?: string | string[];
+    status?: string | string[];
+    group?: string | string[];
     page?: string;
   }>;
 };
@@ -30,9 +30,9 @@ type DevicesPageProps = {
 export default async function DevicesPage({ searchParams }: DevicesPageProps) {
   const params = await searchParams;
 
-  const types = params.type ?? "";
-  const statuses = params.status ?? "";
-  const groups = params.group ?? "";
+  const types = params.type?.toString() ?? "";
+  const statuses = params.status?.toString() ?? "";
+  const groups = params.group?.toString() ?? "";
 
   const typesPromise = getDeviceTypes();
   const statusesPromise = getDeviceStatuses();

--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -58,7 +58,6 @@ export const getDevicesCountByStatus = async (status: string): Promise<ActionRes
 };
 
 export const getDevices = async (
-  limit?: number,
   options: Options = { pagination: { limit: MAX_ROWS, offset: 0 } },
 ): Promise<ActionResult<Device[]>> => {
   try {
@@ -84,7 +83,7 @@ export const getDevices = async (
       .where(sql`${devicesTable.userId} = ${session.userId} ${getSqlWhereStatementByFilters(options.filters)}`)
       .orderBy(getSqlOrderByStatementBySort(options.sort))
       .offset(options.pagination?.offset ?? 0)
-      .limit(options.pagination?.limit ? options.pagination.limit : (limit ?? MAX_ROWS));
+      .limit(options.pagination?.limit ?? MAX_ROWS);
 
     return {
       data,

--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -57,9 +57,7 @@ export const getDevicesCountByStatus = async (status: string): Promise<ActionRes
   }
 };
 
-export const getDevices = async (
-  options: Options = { pagination: { limit: MAX_ROWS } },
-): Promise<ActionResult<Device[]>> => {
+export const getDevices = async (options: Options): Promise<ActionResult<Device[]>> => {
   try {
     const session = await getSession();
 

--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -58,7 +58,7 @@ export const getDevicesCountByStatus = async (status: string): Promise<ActionRes
 };
 
 export const getDevices = async (
-  options: Options = { pagination: { limit: MAX_ROWS, offset: 0 } },
+  options: Options = { pagination: { limit: MAX_ROWS } },
 ): Promise<ActionResult<Device[]>> => {
   try {
     const session = await getSession();

--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { count, desc, eq, ilike } from "drizzle-orm";
+import { count, eq, ilike, sql } from "drizzle-orm";
 
 import { db } from "@/db/client";
 
@@ -8,9 +8,11 @@ import { getSession } from "@/dal/session";
 
 import { MAX_ROWS } from "@/lib/constants";
 
-import type { ActionResult } from "@/lib/definitions";
+import type { ActionResult, Options } from "@/lib/definitions";
 
 import type { Device } from "@/features/device/lib/definitions";
+
+import { getSqlOrderByStatementBySort, getSqlWhereStatementByFilters } from "@/features/device/lib/helpers";
 
 import { deviceGroupsTable, devicesTable, deviceStatusesTable, deviceTypesTable, usersTable } from "@/db/schemas";
 
@@ -55,7 +57,10 @@ export const getDevicesCountByStatus = async (status: string): Promise<ActionRes
   }
 };
 
-export const getDevices = async (limit?: number): Promise<ActionResult<Device[]>> => {
+export const getDevices = async (
+  limit?: number,
+  options: Options = { pagination: { limit: MAX_ROWS, offset: 0 } },
+): Promise<ActionResult<Device[]>> => {
   try {
     const session = await getSession();
 
@@ -76,9 +81,10 @@ export const getDevices = async (limit?: number): Promise<ActionResult<Device[]>
       .innerJoin(deviceTypesTable, eq(devicesTable.typeId, deviceTypesTable.id))
       .innerJoin(deviceStatusesTable, eq(devicesTable.statusId, deviceStatusesTable.id))
       .innerJoin(deviceGroupsTable, eq(devicesTable.groupId, deviceGroupsTable.id))
-      .where(eq(devicesTable.userId, session.userId))
-      .orderBy(desc(devicesTable.createdAt))
-      .limit(limit ?? MAX_ROWS);
+      .where(sql`${devicesTable.userId} = ${session.userId} ${getSqlWhereStatementByFilters(options.filters)}`)
+      .orderBy(getSqlOrderByStatementBySort(options.sort))
+      .offset(options.pagination?.offset ?? 0)
+      .limit(options.pagination?.limit ? options.pagination.limit : (limit ?? MAX_ROWS));
 
     return {
       data,

--- a/src/features/device/components/clear-filter-button.tsx
+++ b/src/features/device/components/clear-filter-button.tsx
@@ -6,14 +6,23 @@ import { Button } from "@/components/ui/button";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
+import useSearchBar from "@/features/device/hooks/use-search-bar";
+
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export default function ClearFilterButton() {
   const pathname = usePathname();
+
   const { replace } = useRouter();
+
   const searchParams = useSearchParams();
 
-  const clearFilters = () => replace(pathname);
+  const searchBar = useSearchBar();
+
+  const clearFilters = () => {
+    searchBar?.handleReset();
+    replace(pathname);
+  };
 
   if (!searchParams.size) {
     return false;

--- a/src/features/device/components/device-search-bar.tsx
+++ b/src/features/device/components/device-search-bar.tsx
@@ -2,12 +2,26 @@
 
 import { SearchIcon } from "lucide-react";
 
+import useSearchBar from "@/features/device/hooks/use-search-bar";
+
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
 
 export default function DeviceSearchBar() {
+  const searchBar = useSearchBar();
+
+  const handleChange = (value: string) => {
+    searchBar?.setQuery(value);
+    searchBar?.handleSearch(value);
+  };
+
   return (
     <InputGroup>
-      <InputGroupInput id="input-device-query" type="search" placeholder="Search..." />
+      <InputGroupInput
+        type="search"
+        placeholder="Search..."
+        value={searchBar?.query}
+        onChange={(e) => handleChange(e.target.value)}
+      />
       <InputGroupAddon align={undefined}>
         <SearchIcon />
       </InputGroupAddon>

--- a/src/features/device/components/device-table-skeleton.tsx
+++ b/src/features/device/components/device-table-skeleton.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@/lib/utils";
+
+import { getDeviceTableColumns } from "@/features/device/lib/utils";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function DeviceTableSkeleton() {
+  const columns = getDeviceTableColumns();
+  const rows = new Array(8).fill(null);
+
+  return (
+    <div className="overflow-hidden border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {columns.map((column) => {
+              const isActionsColumn = column.toLowerCase() === "actions";
+
+              return (
+                <TableHead key={column} className={cn("px-4", isActionsColumn ? "text-right" : "")}>
+                  <span className={isActionsColumn ? "sr-only" : ""}>{column}</span>
+                </TableHead>
+              );
+            })}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((_, idx) => {
+            return (
+              <TableRow key={`device-table-skeleton-row-${idx}`} className="[&>td]:px-4">
+                {columns.map((_, idx) => (
+                  <TableCell key={`device-table-skeleton-cell-${idx}`} className="h-10" align="right">
+                    <Skeleton className={cn("h-3 w-full", `${idx === columns.length - 1 ? "w-6" : ""}`)} />
+                  </TableCell>
+                ))}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -18,6 +18,12 @@ import DeviceActions from "@/features/device/components/device-actions";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
+import {
+  NoResultsFoundRow,
+  NoResultsFoundDescription,
+  NoResultsFoundIcon,
+} from "@/features/device/components/no-results-found-row";
+
 type DeviceTableProps = {
   types: string;
   statuses: string;
@@ -29,7 +35,7 @@ export default async function DeviceTable({ types, statuses, groups }: DeviceTab
     filters: { type: types, status: statuses, group: groups },
   };
 
-  const { data } = await getDevices(options);
+  const { data, error } = await getDevices(options);
 
   const columns = getDeviceTableColumns();
 
@@ -50,6 +56,12 @@ export default async function DeviceTable({ types, statuses, groups }: DeviceTab
           </TableRow>
         </TableHeader>
         <TableBody>
+          {(error || !data?.length) && (
+            <NoResultsFoundRow columns={columns.length}>
+              <NoResultsFoundIcon />
+              <NoResultsFoundDescription>No devices to display.</NoResultsFoundDescription>
+            </NoResultsFoundRow>
+          )}
           {data?.map((device) => {
             return (
               <TableRow key={device.id} className="[&>td]:px-4">

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -25,14 +25,15 @@ import {
 } from "@/features/device/components/no-results-found-row";
 
 type DeviceTableProps = {
+  query: string;
   types: string;
   statuses: string;
   groups: string;
 };
 
-export default async function DeviceTable({ types, statuses, groups }: DeviceTableProps) {
+export default async function DeviceTable({ query, types, statuses, groups }: DeviceTableProps) {
   const options: Options = {
-    filters: { type: types, status: statuses, group: groups },
+    filters: { query, type: types, status: statuses, group: groups },
   };
 
   const { data, error } = await getDevices(options);

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -29,7 +29,7 @@ export default async function DeviceTable({ types, statuses, groups }: DeviceTab
     filters: { type: types, status: statuses, group: groups },
   };
 
-  const { data } = await getDevices(10, options);
+  const { data } = await getDevices(options);
 
   const columns = getDeviceTableColumns();
 

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -4,6 +4,8 @@ import { getDevices } from "@/dal/device";
 
 import { cn } from "@/lib/utils";
 
+import type { Options } from "@/lib/definitions";
+
 import { getDeviceTableColumns } from "@/features/device/lib/utils";
 
 import { getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
@@ -16,8 +18,18 @@ import DeviceActions from "@/features/device/components/device-actions";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
-export default async function DeviceTable() {
-  const { data } = await getDevices();
+type DeviceTableProps = {
+  types: string;
+  statuses: string;
+  groups: string;
+};
+
+export default async function DeviceTable({ types, statuses, groups }: DeviceTableProps) {
+  const options: Options = {
+    filters: { type: types, status: statuses, group: groups },
+  };
+
+  const { data } = await getDevices(10, options);
 
   const columns = getDeviceTableColumns();
 

--- a/src/features/device/components/filter-button-skeleton.tsx
+++ b/src/features/device/components/filter-button-skeleton.tsx
@@ -1,0 +1,9 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function FilterButtonSkeleton() {
+  return (
+    <div className="flex h-8 items-center">
+      <Skeleton className="h-4 w-16" />
+    </div>
+  );
+}

--- a/src/features/device/components/filter-popover.tsx
+++ b/src/features/device/components/filter-popover.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { use, useState } from "react";
 
 import { ChevronDownIcon } from "lucide-react";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import type { ActionResult } from "@/lib/definitions";
 
 import { getFilteredSearchParams } from "@/features/device/lib/utils";
 
@@ -27,10 +29,14 @@ import {
 
 type FilterPopoverProps = {
   label: string;
-  items: string[];
+  items: Promise<ActionResult<{ id: string; name: string }[]>>;
 };
 
 export default function FilterPopover({ label, items }: FilterPopoverProps) {
+  const { data } = use(items);
+
+  const newItems = data?.map(({ name }) => name) ?? [];
+
   const pathname = usePathname();
 
   const { replace } = useRouter();
@@ -43,7 +49,7 @@ export default function FilterPopover({ label, items }: FilterPopoverProps) {
 
   const iconStyles = `${popoverOpen ? "rotate-180" : "rotate-0"} transition-transform`;
 
-  const searchParamsValues = getFilteredSearchParams(searchParams.getAll(label.toLowerCase()), items);
+  const searchParamsValues = getFilteredSearchParams(searchParams.getAll(label.toLowerCase()), newItems);
 
   const updateQueryString = (values: typeof searchParamsValues) => {
     const params = new URLSearchParams(searchParams);
@@ -73,7 +79,7 @@ export default function FilterPopover({ label, items }: FilterPopoverProps) {
         <Combobox
           multiple
           autoHighlight
-          items={items}
+          items={newItems}
           value={searchParamsValues}
           onValueChange={(value) => updateQueryString(value)}
         >
@@ -81,10 +87,9 @@ export default function FilterPopover({ label, items }: FilterPopoverProps) {
             <ComboboxValue>
               {(values) => (
                 <>
-                  {values.map((value: string) => {
-                    const [filteredValue] = items.filter((item) => item.toLowerCase() === value.toLowerCase());
-                    return <ComboboxChip key={filteredValue}>{filteredValue}</ComboboxChip>;
-                  })}
+                  {values.map((value: string) => (
+                    <ComboboxChip key={value}>{value}</ComboboxChip>
+                  ))}
                   <ComboboxChipsInput type="search" />
                 </>
               )}

--- a/src/features/device/components/no-results-found-row.tsx
+++ b/src/features/device/components/no-results-found-row.tsx
@@ -1,0 +1,21 @@
+import { DatabaseIcon } from "lucide-react";
+
+import { TableCell, TableRow } from "@/components/ui/table";
+
+export function NoResultsFoundRow({ columns, children }: { columns: number; children: React.ReactNode }) {
+  return (
+    <TableRow>
+      <TableCell colSpan={columns}>
+        <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">{children}</div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export function NoResultsFoundIcon() {
+  return <DatabaseIcon className="text-muted-foreground size-5" />;
+}
+
+export function NoResultsFoundDescription({ children }: { children: string }) {
+  return <span>{children}</span>;
+}

--- a/src/features/device/components/recent-devices.tsx
+++ b/src/features/device/components/recent-devices.tsx
@@ -25,7 +25,7 @@ import DeviceActions from "@/features/device/components/device-actions";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export default async function RecentDevices() {
-  const { data, error } = await getDevices(5);
+  const { data, error } = await getDevices({ pagination: { limit: 5, offset: 0 } });
 
   const types = await getDeviceTypes();
 

--- a/src/features/device/components/recent-devices.tsx
+++ b/src/features/device/components/recent-devices.tsx
@@ -25,7 +25,7 @@ import DeviceActions from "@/features/device/components/device-actions";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export default async function RecentDevices() {
-  const { data, error } = await getDevices({ pagination: { limit: 5, offset: 0 } });
+  const { data, error } = await getDevices({ pagination: { limit: 5 } });
 
   const types = await getDeviceTypes();
 

--- a/src/features/device/hooks/use-search-bar.tsx
+++ b/src/features/device/hooks/use-search-bar.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useContext } from "react";
+
+import { SearchContext } from "@/features/device/providers/search-provider";
+
+export default function useSearchBar() {
+  return useContext(SearchContext);
+}

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -53,7 +53,7 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
     const partialQuery = sql.join([`%${filters.query}%`]);
     query = sql.join([
       query,
-      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery} OR ${deviceStatusesTable.name} ILIKE ${partialQuery} OR ${deviceGroupsTable.name} ILIKE ${partialQuery} OR ${devicesTable.serialNumber} ILIKE ${partialQuery})`,
+      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery} OR ${deviceStatusesTable.name} ILIKE ${partialQuery} OR ${deviceGroupsTable.name} ILIKE ${partialQuery} OR ${devicesTable.serialNumber} ILIKE ${partialQuery} OR ${devicesTable.ipAddress} ILIKE ${partialQuery})`,
     ]);
   }
 

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -35,6 +35,10 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
   Object.entries(filters).forEach((filter) => {
     const [key, value] = filter;
 
+    if (key === "query") {
+      return;
+    }
+
     const patterns = value.split(",").map((value) => `%${value}%`);
 
     const partialQuery = sql.join(
@@ -44,6 +48,11 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
 
     query = sql.join([query, sql`AND ${getTableColumn(key)} ILIKE ANY (ARRAY[${partialQuery}])`]);
   });
+
+  if (filters.query) {
+    const partialQuery = sql.join([`%${filters.query}%`]);
+    query = sql.join([query, sql`AND ${devicesTable.name} ILIKE ${partialQuery}`]);
+  }
 
   return query;
 };

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -1,0 +1,60 @@
+import { sql } from "drizzle-orm";
+
+import type { Options } from "@/lib/definitions";
+
+import { deviceGroupsTable, devicesTable, deviceStatusesTable, deviceTypesTable } from "@/db/schemas";
+
+export const getSqlOrderByStatementBySort = (sort: Options["sort"]) => {
+  if (!sort) return sql`${devicesTable.createdAt} ASC`;
+
+  const getTableColumn = (column: string) => {
+    switch (column) {
+      case "name":
+        return devicesTable.name;
+      case "type":
+        return deviceTypesTable.name;
+      case "status":
+        return deviceStatusesTable.name;
+      case "group":
+        return deviceGroupsTable.name;
+      case "serialNumber":
+        return devicesTable.serialNumber;
+      case "ipAddress":
+        return devicesTable.ipAddress;
+    }
+  };
+
+  return sql`${getTableColumn(sort.column)} ${sort.direction === "asc" ? sql`ASC` : sql`DESC`}`;
+};
+
+export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
+  let query = sql``;
+
+  if (!filters) return query;
+
+  const getTableColumn = (key: string) => {
+    switch (key) {
+      case "type":
+        return deviceTypesTable.name;
+      case "status":
+        return deviceStatusesTable.name;
+      case "group":
+        return deviceGroupsTable.name;
+    }
+  };
+
+  Object.entries(filters).forEach((filter) => {
+    const [key, value] = filter;
+
+    const patterns = value.split(",").map((value) => `%${value}%`);
+
+    const partialQuery = sql.join(
+      patterns.map((pattern) => sql`${pattern}`),
+      sql`, `,
+    );
+
+    query = sql.join([query, sql`AND ${getTableColumn(key)} ILIKE ANY (ARRAY[${partialQuery}])`]);
+  });
+
+  return query;
+};

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -36,6 +36,19 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
     const [key, value] = filter;
 
     if (key === "query") {
+      const partialQuery = sql.join([`%${filters.query}%`]);
+      const deviceNameQuery = sql`${getTableColumn("name")} ILIKE ${partialQuery}`;
+      const deviceTypeQuery = sql`${getTableColumn("type")} ILIKE ${partialQuery}`;
+      const deviceStatusQuery = sql`${getTableColumn("status")} ILIKE ${partialQuery}`;
+      const deviceGroupQuery = sql`${getTableColumn("group")} ILIKE ${partialQuery}`;
+      const deviceSerialNumberQuery = sql`${getTableColumn("serialNumber")} ILIKE ${partialQuery}`;
+      const deviceIpAddressQuery = sql`${getTableColumn("ipAddress")} ILIKE ${partialQuery}`;
+
+      query = sql.join([
+        query,
+        sql`AND (${deviceNameQuery} OR ${deviceTypeQuery} OR ${deviceStatusQuery} OR ${deviceGroupQuery} OR ${deviceSerialNumberQuery} OR ${deviceIpAddressQuery})`,
+      ]);
+
       return;
     }
 
@@ -48,14 +61,6 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
 
     query = sql.join([query, sql`AND ${getTableColumn(key)} ILIKE ANY (ARRAY[${partialQuery}])`]);
   });
-
-  if (filters.query) {
-    const partialQuery = sql.join([`%${filters.query}%`]);
-    query = sql.join([
-      query,
-      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery} OR ${deviceStatusesTable.name} ILIKE ${partialQuery} OR ${deviceGroupsTable.name} ILIKE ${partialQuery} OR ${devicesTable.serialNumber} ILIKE ${partialQuery} OR ${devicesTable.ipAddress} ILIKE ${partialQuery})`,
-    ]);
-  }
 
   return query;
 };

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -53,7 +53,7 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
     const partialQuery = sql.join([`%${filters.query}%`]);
     query = sql.join([
       query,
-      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery})`,
+      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery} OR ${deviceStatusesTable.name} ILIKE ${partialQuery})`,
     ]);
   }
 

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -51,7 +51,10 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
 
   if (filters.query) {
     const partialQuery = sql.join([`%${filters.query}%`]);
-    query = sql.join([query, sql`AND ${devicesTable.name} ILIKE ${partialQuery}`]);
+    query = sql.join([
+      query,
+      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery})`,
+    ]);
   }
 
   return query;

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -53,7 +53,7 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
     const partialQuery = sql.join([`%${filters.query}%`]);
     query = sql.join([
       query,
-      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery} OR ${deviceStatusesTable.name} ILIKE ${partialQuery})`,
+      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery} OR ${deviceStatusesTable.name} ILIKE ${partialQuery} OR ${deviceGroupsTable.name} ILIKE ${partialQuery})`,
     ]);
   }
 

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -4,25 +4,25 @@ import type { Options } from "@/lib/definitions";
 
 import { deviceGroupsTable, devicesTable, deviceStatusesTable, deviceTypesTable } from "@/db/schemas";
 
+const getTableColumn = (column: string) => {
+  switch (column) {
+    case "name":
+      return devicesTable.name;
+    case "type":
+      return deviceTypesTable.name;
+    case "status":
+      return deviceStatusesTable.name;
+    case "group":
+      return deviceGroupsTable.name;
+    case "serialNumber":
+      return devicesTable.serialNumber;
+    case "ipAddress":
+      return devicesTable.ipAddress;
+  }
+};
+
 export const getSqlOrderByStatementBySort = (sort: Options["sort"]) => {
   if (!sort) return sql`${devicesTable.createdAt} ASC`;
-
-  const getTableColumn = (column: string) => {
-    switch (column) {
-      case "name":
-        return devicesTable.name;
-      case "type":
-        return deviceTypesTable.name;
-      case "status":
-        return deviceStatusesTable.name;
-      case "group":
-        return deviceGroupsTable.name;
-      case "serialNumber":
-        return devicesTable.serialNumber;
-      case "ipAddress":
-        return devicesTable.ipAddress;
-    }
-  };
 
   return sql`${getTableColumn(sort.column)} ${sort.direction === "asc" ? sql`ASC` : sql`DESC`}`;
 };
@@ -31,17 +31,6 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
   let query = sql``;
 
   if (!filters) return query;
-
-  const getTableColumn = (key: string) => {
-    switch (key) {
-      case "type":
-        return deviceTypesTable.name;
-      case "status":
-        return deviceStatusesTable.name;
-      case "group":
-        return deviceGroupsTable.name;
-    }
-  };
 
   Object.entries(filters).forEach((filter) => {
     const [key, value] = filter;

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -53,7 +53,7 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
     const partialQuery = sql.join([`%${filters.query}%`]);
     query = sql.join([
       query,
-      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery} OR ${deviceStatusesTable.name} ILIKE ${partialQuery} OR ${deviceGroupsTable.name} ILIKE ${partialQuery})`,
+      sql`AND (${devicesTable.name} ILIKE ${partialQuery} OR ${deviceTypesTable.name} ILIKE ${partialQuery} OR ${deviceStatusesTable.name} ILIKE ${partialQuery} OR ${deviceGroupsTable.name} ILIKE ${partialQuery} OR ${devicesTable.serialNumber} ILIKE ${partialQuery})`,
     ]);
   }
 

--- a/src/features/device/providers/search-provider.tsx
+++ b/src/features/device/providers/search-provider.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { createContext, useState } from "react";
+
+import { type DebouncedState, useDebouncedCallback } from "use-debounce";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type SearchContextProps = {
+  query: string;
+  setQuery: (value: string) => void;
+  handleSearch: DebouncedState<(value: string) => void>;
+  handleReset: () => void;
+};
+
+export const SearchContext = createContext<SearchContextProps | null>(null);
+
+export default function SearchProvider({ children }: { children: React.ReactNode }) {
+  const searchParams = useSearchParams();
+
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
+
+  const pathname = usePathname();
+
+  const { replace } = useRouter();
+
+  const handleSearch = useDebouncedCallback((value: string) => {
+    const params = new URLSearchParams(searchParams);
+
+    if (value) params.set("q", value.trim().toLowerCase());
+    else params.delete("q");
+
+    replace(`${pathname}?${params.toString()}`);
+  }, 300);
+
+  const handleReset = () => {
+    setQuery("");
+  };
+
+  const contextValue = {
+    query,
+    setQuery: (value: string) => setQuery(value),
+    handleSearch,
+    handleReset,
+  };
+
+  return <SearchContext.Provider value={contextValue}>{children}</SearchContext.Provider>;
+}

--- a/src/features/device/providers/search-provider.tsx
+++ b/src/features/device/providers/search-provider.tsx
@@ -27,7 +27,7 @@ export default function SearchProvider({ children }: { children: React.ReactNode
   const handleSearch = useDebouncedCallback((value: string) => {
     const params = new URLSearchParams(searchParams);
 
-    if (value) params.set("q", value.trim().toLowerCase());
+    if (value.trim()) params.set("q", value.trim().toLowerCase());
     else params.delete("q");
 
     replace(`${pathname}?${params.toString()}`);

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -5,7 +5,7 @@ export type ActionReturnType<T extends object> = Promise<{ success: boolean; ser
 export type Options = {
   pagination?: {
     limit: number;
-    offset: number;
+    offset?: number;
   };
   sort?: {
     column: string;

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -1,3 +1,15 @@
 export type ActionResult<T> = { data: T; error: null } | { data: null; error: string };
 
 export type ActionReturnType<T extends object> = Promise<{ success: boolean; serverErrors: T | null }>;
+
+export type Options = {
+  pagination?: {
+    limit: number;
+    offset: number;
+  };
+  sort?: {
+    column: string;
+    direction: "asc" | "desc";
+  };
+  filters?: Record<string, string>;
+};


### PR DESCRIPTION
This PR enhances filtering by allowing users to filter devices by name, type, status, group, serial number, and IP address.

## Changes
- Built the `Options` type that includes pagination, sort, and filters.
- Built an SQL helper for sorting the devices by their creation date in ascending order.
- Built an SQL helper for filtering devices by name, type, status, group, serial number, and IP address.
- Replaced static JSON data with data from the db.
- Built the filter button and table loading skeleton.
- Built a search provider for the search bar and the filter button to manage shared state.
- Updated `DevicePageProps` that shows type, status, and group params may be an array of strings.