### PR TITLE
Feature/sort devices table

### DIFF
--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -33,6 +33,8 @@ type DevicesPageProps = {
     group?: string | string[];
     page?: string;
     q?: string;
+    sortBy?: string;
+    sortDirection?: string;
   }>;
 };
 
@@ -43,6 +45,8 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
   const types = params.type?.toString() ?? "";
   const statuses = params.status?.toString() ?? "";
   const groups = params.group?.toString() ?? "";
+  const sortBy = params.sortBy ?? "";
+  const sortDirection = params.sortDirection ?? "";
 
   const typesPromise = getDeviceTypes();
   const statusesPromise = getDeviceStatuses();
@@ -89,7 +93,14 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
           </ButtonGroup>
         </SearchProvider>
         <Suspense fallback={<DeviceTableSkeleton />}>
-          <DeviceTable query={query} types={types} statuses={statuses} groups={groups} />
+          <DeviceTable
+            query={query}
+            types={types}
+            statuses={statuses}
+            groups={groups}
+            sortBy={sortBy}
+            sortDirection={sortDirection}
+          />
         </Suspense>
       </main>
     </>

--- a/src/features/device/components/device-table-columns.tsx
+++ b/src/features/device/components/device-table-columns.tsx
@@ -2,61 +2,25 @@
 
 import { cn } from "@/lib/utils";
 
-import { useState } from "react";
-
 import { ChevronUpIcon } from "lucide-react";
-
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { getDeviceTableColumns } from "@/features/device/lib/utils";
 
 import type { SortDirection } from "@/features/device/lib/definitions";
 
-import { SORT_BY_PARAM_ID, SORT_DIRECTION_PARAM_ID } from "@/features/device/lib/constants";
+import useSort from "@/features/device/hooks/use-sort";
 
 import { TableHead } from "@/components/ui/table";
 
 type DeviceTableColumnsProps = ReturnType<typeof getDeviceTableColumns>;
 
 export default function DeviceTableColumns({ columns }: { columns: DeviceTableColumnsProps }) {
-  const pathname = usePathname();
-
-  const { replace } = useRouter();
-
-  const searchParams = useSearchParams();
-
-  const getInitialState = () => {
-    const sortBy = searchParams.get(SORT_BY_PARAM_ID) || "";
-    const sortDirection = searchParams.get(SORT_DIRECTION_PARAM_ID) || "asc";
-
-    if (!sortBy && !sortDirection) return null;
-
-    return {
-      name: sortBy,
-      direction: sortDirection as SortDirection,
-    };
-  };
-
-  const [sortBy, setSortBy] = useState<{ name: string; direction: SortDirection } | null>(getInitialState());
+  const { sort, handleSort } = useSort();
 
   return columns.map((tableColumn) => {
     const isActionsColumn = tableColumn.toLowerCase() === "actions";
 
-    const handleSort = (value: string) => {
-      const newSortByDirection = sortBy?.name === value.toLowerCase() && sortBy?.direction === "asc" ? "desc" : "asc";
-
-      setSortBy({ name: value.toLowerCase(), direction: newSortByDirection });
-
-      const params = new URLSearchParams(searchParams);
-
-      params.set(SORT_BY_PARAM_ID, value.toLowerCase());
-
-      params.set(SORT_DIRECTION_PARAM_ID, newSortByDirection);
-
-      replace(`${pathname}?${params.toString()}`);
-    };
-
-    const isSortedColumn = tableColumn.toLowerCase() === sortBy?.name;
+    const isSortedColumn = tableColumn.toLowerCase() === sort?.name;
 
     return (
       <TableHead
@@ -66,7 +30,7 @@ export default function DeviceTableColumns({ columns }: { columns: DeviceTableCo
       >
         <div className="flex items-center gap-1">
           <span className={isActionsColumn ? "sr-only" : undefined}>{tableColumn}</span>
-          {!isActionsColumn && isSortedColumn && <SortIcon direction={sortBy.direction} />}
+          {!isActionsColumn && isSortedColumn && <SortIcon direction={sort.direction} />}
         </div>
       </TableHead>
     );

--- a/src/features/device/components/device-table-columns.tsx
+++ b/src/features/device/components/device-table-columns.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+import { useState } from "react";
+
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+import { getDeviceTableColumns } from "@/features/device/lib/utils";
+
+import { TableHead } from "@/components/ui/table";
+
+type DeviceTableColumnsProps = ReturnType<typeof getDeviceTableColumns>;
+
+export default function DeviceTableColumns({ columns }: { columns: DeviceTableColumnsProps }) {
+  const [sortBy, setSortBy] = useState<{ name: string; direction: "asc" | "desc" } | null>(null);
+
+  return columns.map((tableColumn) => {
+    const isActionsColumn = tableColumn.toLowerCase() === "actions";
+
+    const handleSort = (value: string) => {
+      setSortBy((prevState) => ({
+        name: value.toLowerCase(),
+        direction: prevState?.direction === "asc" ? "desc" : "asc",
+      }));
+    };
+
+    const isSortedColumn = tableColumn.toLowerCase() === sortBy?.name;
+
+    return (
+      <TableHead
+        key={tableColumn}
+        className={cn("cursor-pointer px-4", isActionsColumn ? "text-right" : "")}
+        onClick={!isActionsColumn ? (e) => handleSort(e.currentTarget.innerText) : undefined}
+      >
+        <div className="flex items-center gap-1">
+          <span className={isActionsColumn ? "sr-only" : ""}>{tableColumn}</span>
+          {!isActionsColumn && isSortedColumn && <SortIcon direction={sortBy?.direction} />}
+        </div>
+      </TableHead>
+    );
+  });
+}
+
+function SortIcon({ direction }: { direction?: "asc" | "desc" }) {
+  return direction === "asc" ? <ChevronDownIcon className="size-3" /> : <ChevronUpIcon className="size-3" />;
+}

--- a/src/features/device/components/device-table-columns.tsx
+++ b/src/features/device/components/device-table-columns.tsx
@@ -4,25 +4,56 @@ import { cn } from "@/lib/utils";
 
 import { useState } from "react";
 
-import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { ChevronUpIcon } from "lucide-react";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { getDeviceTableColumns } from "@/features/device/lib/utils";
+
+import type { SortDirection } from "@/features/device/lib/definitions";
+
+import { SORT_BY_PARAM_ID, SORT_DIRECTION_PARAM_ID } from "@/features/device/lib/constants";
 
 import { TableHead } from "@/components/ui/table";
 
 type DeviceTableColumnsProps = ReturnType<typeof getDeviceTableColumns>;
 
 export default function DeviceTableColumns({ columns }: { columns: DeviceTableColumnsProps }) {
-  const [sortBy, setSortBy] = useState<{ name: string; direction: "asc" | "desc" } | null>(null);
+  const pathname = usePathname();
+
+  const { replace } = useRouter();
+
+  const searchParams = useSearchParams();
+
+  const getInitialState = () => {
+    const sortBy = searchParams.get(SORT_BY_PARAM_ID) || "";
+    const sortDirection = searchParams.get(SORT_DIRECTION_PARAM_ID) || "asc";
+
+    if (!sortBy && !sortDirection) return null;
+
+    return {
+      name: sortBy,
+      direction: sortDirection as SortDirection,
+    };
+  };
+
+  const [sortBy, setSortBy] = useState<{ name: string; direction: SortDirection } | null>(getInitialState());
 
   return columns.map((tableColumn) => {
     const isActionsColumn = tableColumn.toLowerCase() === "actions";
 
     const handleSort = (value: string) => {
-      setSortBy((prevState) => ({
-        name: value.toLowerCase(),
-        direction: prevState?.direction === "asc" ? "desc" : "asc",
-      }));
+      const newSortByDirection = sortBy?.name === value.toLowerCase() && sortBy?.direction === "asc" ? "desc" : "asc";
+
+      setSortBy({ name: value.toLowerCase(), direction: newSortByDirection });
+
+      const params = new URLSearchParams(searchParams);
+
+      params.set(SORT_BY_PARAM_ID, value.toLowerCase());
+
+      params.set(SORT_DIRECTION_PARAM_ID, newSortByDirection);
+
+      replace(`${pathname}?${params.toString()}`);
     };
 
     const isSortedColumn = tableColumn.toLowerCase() === sortBy?.name;
@@ -30,18 +61,20 @@ export default function DeviceTableColumns({ columns }: { columns: DeviceTableCo
     return (
       <TableHead
         key={tableColumn}
-        className={cn("cursor-pointer px-4", isActionsColumn ? "text-right" : "")}
+        className={cn("px-4", isActionsColumn ? "text-right" : "hover:bg-accent cursor-pointer")}
         onClick={!isActionsColumn ? (e) => handleSort(e.currentTarget.innerText) : undefined}
       >
         <div className="flex items-center gap-1">
-          <span className={isActionsColumn ? "sr-only" : ""}>{tableColumn}</span>
-          {!isActionsColumn && isSortedColumn && <SortIcon direction={sortBy?.direction} />}
+          <span className={isActionsColumn ? "sr-only" : undefined}>{tableColumn}</span>
+          {!isActionsColumn && isSortedColumn && <SortIcon direction={sortBy.direction} />}
         </div>
       </TableHead>
     );
   });
 }
 
-function SortIcon({ direction }: { direction?: "asc" | "desc" }) {
-  return direction === "asc" ? <ChevronDownIcon className="size-3" /> : <ChevronUpIcon className="size-3" />;
+function SortIcon({ direction }: { direction: SortDirection }) {
+  const rotationStyle = direction === "asc" ? "rotate-0" : "rotate-180";
+
+  return <ChevronUpIcon className={cn("size-3 transition-transform", rotationStyle)} />;
 }

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -8,6 +8,8 @@ import type { Options } from "@/lib/definitions";
 
 import { getDeviceTableColumns } from "@/features/device/lib/utils";
 
+import type { SortDirection } from "@/features/device/lib/definitions";
+
 import { getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
 
 import { Badge } from "@/components/ui/badge";
@@ -31,10 +33,16 @@ type DeviceTableProps = {
   types: string;
   statuses: string;
   groups: string;
+  sortBy: string;
+  sortDirection: string;
 };
 
-export default async function DeviceTable({ query, types, statuses, groups }: DeviceTableProps) {
+export default async function DeviceTable({ query, types, statuses, groups, sortBy, sortDirection }: DeviceTableProps) {
   const options: Options = {
+    sort: {
+      column: sortBy,
+      direction: sortDirection as SortDirection,
+    },
     filters: { query, type: types, status: statuses, group: groups },
   };
 

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -16,7 +16,9 @@ import { buttonVariants } from "@/components/ui/button";
 
 import DeviceActions from "@/features/device/components/device-actions";
 
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import DeviceTableColumns from "@/features/device/components/device-table-columns";
+
+import { Table, TableBody, TableCell, TableHeader, TableRow } from "@/components/ui/table";
 
 import {
   NoResultsFoundRow,
@@ -45,15 +47,7 @@ export default async function DeviceTable({ query, types, statuses, groups }: De
       <Table>
         <TableHeader>
           <TableRow>
-            {columns.map((tableColumn) => {
-              const isActionsColumn = tableColumn.toLowerCase() === "actions";
-
-              return (
-                <TableHead key={tableColumn} className={cn("px-4", isActionsColumn ? "text-right" : "")}>
-                  <span className={isActionsColumn ? "sr-only" : ""}>{tableColumn}</span>
-                </TableHead>
-              );
-            })}
+            <DeviceTableColumns columns={columns} />
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/src/features/device/hooks/use-sort.tsx
+++ b/src/features/device/hooks/use-sort.tsx
@@ -1,25 +1,10 @@
 "use client";
 
-import { useState } from "react";
-
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import type { SortDirection } from "@/features/device/lib/definitions";
 
 import { SORT_BY_PARAM_ID, SORT_DIRECTION_PARAM_ID } from "@/features/device/lib/constants";
-
-type SortProps = {
-  name: string;
-  direction: SortDirection;
-};
-
-const createInitialState = (sortProps: SortProps) => {
-  const { name, direction } = sortProps;
-
-  if (!name || !direction) return null;
-
-  return { name, direction };
-};
 
 export default function useSort() {
   const pathname = usePathname();
@@ -28,17 +13,13 @@ export default function useSort() {
 
   const searchParams = useSearchParams();
 
-  const [sort, setSort] = useState<SortProps | null>(
-    createInitialState({
-      name: searchParams.get(SORT_BY_PARAM_ID) || "",
-      direction: (searchParams.get(SORT_DIRECTION_PARAM_ID) as SortDirection) || "asc",
-    }),
-  );
+  const sort = {
+    name: searchParams.get(SORT_BY_PARAM_ID) || "",
+    direction: (searchParams.get(SORT_DIRECTION_PARAM_ID) as SortDirection) || "asc",
+  };
 
   const handleSort = (value: string) => {
     const newSortByDirection = sort?.name === value.toLowerCase() && sort?.direction === "asc" ? "desc" : "asc";
-
-    setSort({ name: value.toLowerCase(), direction: newSortByDirection });
 
     const params = new URLSearchParams(searchParams);
 

--- a/src/features/device/hooks/use-sort.tsx
+++ b/src/features/device/hooks/use-sort.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import type { SortDirection } from "@/features/device/lib/definitions";
+
+import { SORT_BY_PARAM_ID, SORT_DIRECTION_PARAM_ID } from "@/features/device/lib/constants";
+
+type SortProps = {
+  name: string;
+  direction: SortDirection;
+};
+
+const createInitialState = (sortProps: SortProps) => {
+  const { name, direction } = sortProps;
+
+  if (!name || !direction) return null;
+
+  return { name, direction };
+};
+
+export default function useSort() {
+  const pathname = usePathname();
+
+  const { replace } = useRouter();
+
+  const searchParams = useSearchParams();
+
+  const [sort, setSort] = useState<SortProps | null>(
+    createInitialState({
+      name: searchParams.get(SORT_BY_PARAM_ID) || "",
+      direction: (searchParams.get(SORT_DIRECTION_PARAM_ID) as SortDirection) || "asc",
+    }),
+  );
+
+  const handleSort = (value: string) => {
+    const newSortByDirection = sort?.name === value.toLowerCase() && sort?.direction === "asc" ? "desc" : "asc";
+
+    setSort({ name: value.toLowerCase(), direction: newSortByDirection });
+
+    const params = new URLSearchParams(searchParams);
+
+    params.set(SORT_BY_PARAM_ID, value.toLowerCase());
+
+    params.set(SORT_DIRECTION_PARAM_ID, newSortByDirection);
+
+    replace(`${pathname}?${params.toString()}`);
+  };
+
+  return {
+    sort,
+    handleSort,
+  };
+}

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -9,3 +9,7 @@ export const ACTION_MESSAGE = {
   deleted: "The device was successfully deleted.",
   copied: "The device ID was successfully copied to the clipboard.",
 };
+
+export const SORT_BY_PARAM_ID = "sortBy";
+
+export const SORT_DIRECTION_PARAM_ID = "sortDirection";

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -23,3 +23,5 @@ export type BaseDeviceModalProps<T = object> = {
   deviceId: string;
   onClose: () => void;
 } & T;
+
+export type SortDirection = "asc" | "desc";

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -1,5 +1,7 @@
 import { sql } from "drizzle-orm";
 
+import { camelCase } from "@/lib/utils";
+
 import type { Options } from "@/lib/definitions";
 
 import { deviceGroupsTable, devicesTable, deviceStatusesTable, deviceTypesTable } from "@/db/schemas";
@@ -26,7 +28,9 @@ export const getSqlOrderByStatementBySort = (sort: Options["sort"]) => {
 
   const sortDirection = sort.direction || "asc";
 
-  return sql`${getTableColumn(sort.column)} ${sortDirection === "asc" ? sql`ASC` : sql`DESC`}`;
+  const columnName = camelCase(sort.column);
+
+  return sql`${getTableColumn(columnName)} ${sortDirection === "asc" ? sql`ASC` : sql`DESC`}`;
 };
 
 export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -30,7 +30,11 @@ export const getSqlOrderByStatementBySort = (sort: Options["sort"]) => {
 
   const columnName = camelCase(sort.column);
 
-  return sql`${getTableColumn(columnName)} ${sortDirection === "asc" ? sql`ASC` : sql`DESC`}`;
+  const isIpAddress = columnName === "ipAddress";
+
+  const tableColumn = getTableColumn(columnName);
+
+  return sql`${isIpAddress ? sql`${tableColumn}::inet` : tableColumn} ${sortDirection === "asc" ? sql`ASC` : sql`DESC`}`;
 };
 
 export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -22,9 +22,11 @@ const getTableColumn = (column: string) => {
 };
 
 export const getSqlOrderByStatementBySort = (sort: Options["sort"]) => {
-  if (!sort) return sql`${devicesTable.createdAt} ASC`;
+  if (!sort?.column) return sql`${devicesTable.createdAt} ASC`;
 
-  return sql`${getTableColumn(sort.column)} ${sort.direction === "asc" ? sql`ASC` : sql`DESC`}`;
+  const sortDirection = sort.direction || "asc";
+
+  return sql`${getTableColumn(sort.column)} ${sortDirection === "asc" ? sql`ASC` : sql`DESC`}`;
 };
 
 export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -1,3 +1,5 @@
+import type { SortDirection } from "@/features/device/lib/definitions";
+
 export type ActionResult<T> = { data: T; error: null } | { data: null; error: string };
 
 export type ActionReturnType<T extends object> = Promise<{ success: boolean; serverErrors: T | null }>;
@@ -9,7 +11,7 @@ export type Options = {
   };
   sort?: {
     column: string;
-    direction: "asc" | "desc";
+    direction: SortDirection;
   };
   filters?: Record<string, string>;
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,3 +5,10 @@ import { clsx, type ClassValue } from "clsx";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const camelCase = (value: string) => {
+  return value
+    .split(" ")
+    .map((word, idx) => (Boolean(idx) ? `${word[0].toUpperCase()}${word.slice(1)}` : word))
+    .join("");
+};


### PR DESCRIPTION
This PR features sorting devices by several columns.

## Changes
- Sorted devices by name.
- Sorted devices by type.
- Sorted devices by status.
- Sorted devices by group.
- Sorted devices by serial number.
- Sorted devices by IP address.
- Created a `useSort` hook to manage sorting logic.
- Used `::inet` cast to correctly sort IPv4 addresses.
- Set `sortDirection` to `asc` as default if one is not specified in the URL.