### PR TITLE
Add devices path as a protected page to proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,11 +2,15 @@ import { getSessionCookie } from "better-auth/cookies";
 
 import { type NextRequest, NextResponse } from "next/server";
 
+import { DASHBOARD_PATH, DEVICES_PATH } from "@/features/dashboard/lib/constants";
+
+const protectedPages = [DASHBOARD_PATH, DEVICES_PATH];
+
 export async function proxy(request: NextRequest) {
   const sessionCookie = getSessionCookie(request);
 
   const isAuthPage = request.nextUrl.pathname === "/login";
-  const isProtectedPage = request.nextUrl.pathname.startsWith("/dashboard");
+  const isProtectedPage = protectedPages.includes(request.nextUrl.pathname);
 
   if (sessionCookie && isAuthPage) {
     return NextResponse.redirect(new URL("/dashboard", request.url));
@@ -20,5 +24,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/login"],
+  matcher: ["/dashboard/:path*", "/devices/:path*", "/login"],
 };


### PR DESCRIPTION
This PR adds the devices path as a protected page via `Proxy`.

## Changes
- Created the `protectedPages` array.
- Updated the `isProtectedPage` logic.
- Added `"/devices/:path*"` to the matcher config.