### PR TITLE
Chore/rename description remove unused function

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { ThemeProvider } from "@wrksz/themes/next";
 
 import { cn } from "@/lib/utils";
 
-import { APP_DESC, APP_NAME } from "@/lib/constants";
+import { APP_DESCRIPTION, APP_NAME } from "@/lib/constants";
 
 import { Toaster } from "@/components/ui/sonner";
 
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
     template: `%s | ${APP_NAME}`,
     default: APP_NAME,
   },
-  description: APP_DESC,
+  description: APP_DESCRIPTION,
 };
 
 export default function RootLayout({

--- a/src/features/device/lib/utils.ts
+++ b/src/features/device/lib/utils.ts
@@ -1,7 +1,5 @@
 import { DEFAULT_PAGE_SIZE, PAGE_SIZES, TABLE_COLUMNS } from "@/features/device/lib/constants";
 
-import type { Device } from "@/features/device/lib/definitions";
-
 export const getBadgeIconColorClassesByStatus = (status: string) => {
   switch (status) {
     case "in use":
@@ -16,16 +14,6 @@ export const getBadgeIconColorClassesByStatus = (status: string) => {
 };
 
 export const generateId = (value: string, separator: string = "-") => value.toLowerCase().split(" ").join(separator);
-
-export const generateDeviceFieldIds = (data: Device) => ({
-  id: { name: "id", value: data.id },
-  name: { name: "name", value: data.name },
-  serialNumber: { name: "serial-number", value: data.serialNumber },
-  ipAddress: { name: "ip-address", value: data.ipAddress ?? "" },
-  type: { name: "type", value: "" },
-  status: { name: "status", value: "" },
-  group: { name: "group", value: "" },
-});
 
 export const getDeviceTableColumns = () => {
   const newColumns = TABLE_COLUMNS.slice(0, TABLE_COLUMNS.length - 1);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,6 @@
 export const APP_NAME = "DeviceMGR";
 
-export const APP_DESC = "A device management dashboard built with Next.js.";
+export const APP_DESCRIPTION = "A device management dashboard built with Next.js.";
 
 export const GITHUB_REPO = "https://github.com/starlightroad/devicemgr";
 


### PR DESCRIPTION
This PR renames the app description constant and removes an unused function.

## Changes
- Renamed `APP_DESC`to `APP_DESCRIPTION`.
- Removed the function `generateDeviceFieldIds`.