### PR TITLE
Feature/create new device

### DIFF
--- a/src/app/(dashboard)/devices/new/page.tsx
+++ b/src/app/(dashboard)/devices/new/page.tsx
@@ -1,24 +1,14 @@
-import Link from "next/link";
-
 import { getDeviceTypes } from "@/dal/type";
 
 import { getDeviceGroups } from "@/dal/group";
 
 import { getDeviceStatuses } from "@/dal/status";
 
-import { FORM_ID } from "@/features/device/lib/constants";
-
-import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
-
 import { createSelectFieldItems } from "@/features/device/lib/helpers";
 
-import { Button, buttonVariants } from "@/components/ui/button";
-
-import NewDeviceForm from "@/features/device/components/new-device-form";
+import NewDeviceCard from "@/features/device/components/new-device-card";
 
 import { Header, HeaderTitle } from "@/features/dashboard/components/header";
-
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default async function NewDevicePage() {
   const [types, statuses, groups] = await Promise.all([getDeviceTypes(), getDeviceStatuses(), getDeviceGroups()]);
@@ -29,27 +19,11 @@ export default async function NewDevicePage() {
         <HeaderTitle>Add New Device</HeaderTitle>
       </Header>
       <main className="pb-5">
-        <Card>
-          <CardHeader>
-            <CardTitle>Device Information</CardTitle>
-            <CardDescription>Fill out the following fields to create a new device.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <NewDeviceForm
-              types={createSelectFieldItems(types.data)}
-              statuses={createSelectFieldItems(statuses.data)}
-              groups={createSelectFieldItems(groups.data)}
-            />
-          </CardContent>
-          <CardFooter className="justify-end gap-2">
-            <Link href={DEVICES_PATH} className={buttonVariants({ variant: "outline" })}>
-              Cancel
-            </Link>
-            <Button form={FORM_ID} type="submit">
-              Create Device
-            </Button>
-          </CardFooter>
-        </Card>
+        <NewDeviceCard
+          types={createSelectFieldItems(types.data)}
+          statuses={createSelectFieldItems(statuses.data)}
+          groups={createSelectFieldItems(groups.data)}
+        />
       </main>
     </div>
   );

--- a/src/app/(dashboard)/devices/new/page.tsx
+++ b/src/app/(dashboard)/devices/new/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { getDeviceTypes } from "@/dal/type";
 
 import { getDeviceGroups } from "@/dal/group";
@@ -6,9 +8,11 @@ import { getDeviceStatuses } from "@/dal/status";
 
 import { FORM_ID } from "@/features/device/lib/constants";
 
+import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
+
 import { createSelectFieldItems } from "@/features/device/lib/helpers";
 
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 
 import NewDeviceForm from "@/features/device/components/new-device-form";
 
@@ -38,9 +42,9 @@ export default async function NewDevicePage() {
             />
           </CardContent>
           <CardFooter className="justify-end gap-2">
-            <Button type="button" variant="outline">
+            <Link href={DEVICES_PATH} className={buttonVariants({ variant: "outline" })}>
               Cancel
-            </Button>
+            </Link>
             <Button form={FORM_ID} type="submit">
               Create Device
             </Button>

--- a/src/app/(dashboard)/devices/new/page.tsx
+++ b/src/app/(dashboard)/devices/new/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+
 import { getDeviceTypes } from "@/dal/type";
 
 import { getDeviceGroups } from "@/dal/group";
@@ -6,9 +8,16 @@ import { getDeviceStatuses } from "@/dal/status";
 
 import { createSelectFieldItems } from "@/features/device/lib/helpers";
 
+import { NEW_DEVICE_DESCRIPTION, NEW_DEVICE_TITLE } from "@/features/device/lib/constants";
+
 import NewDeviceCard from "@/features/device/components/new-device-card";
 
 import { Header, HeaderTitle } from "@/features/dashboard/components/header";
+
+export const metadata: Metadata = {
+  title: NEW_DEVICE_TITLE,
+  description: NEW_DEVICE_DESCRIPTION,
+};
 
 export default async function NewDevicePage() {
   const [types, statuses, groups] = await Promise.all([getDeviceTypes(), getDeviceStatuses(), getDeviceGroups()]);

--- a/src/app/(dashboard)/devices/new/page.tsx
+++ b/src/app/(dashboard)/devices/new/page.tsx
@@ -1,0 +1,52 @@
+import { getDeviceTypes } from "@/dal/type";
+
+import { getDeviceGroups } from "@/dal/group";
+
+import { getDeviceStatuses } from "@/dal/status";
+
+import { FORM_ID } from "@/features/device/lib/constants";
+
+import { createSelectFieldItems } from "@/features/device/lib/helpers";
+
+import { Button } from "@/components/ui/button";
+
+import NewDeviceForm from "@/features/device/components/new-device-form";
+
+import { Header, HeaderTitle } from "@/features/dashboard/components/header";
+
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default async function NewDevicePage() {
+  const [types, statuses, groups] = await Promise.all([getDeviceTypes(), getDeviceStatuses(), getDeviceGroups()]);
+
+  return (
+    <div className="mx-auto max-w-xl">
+      <Header>
+        <HeaderTitle>Add New Device</HeaderTitle>
+      </Header>
+      <main className="pb-5">
+        <Card>
+          <CardHeader>
+            <CardTitle>Device Information</CardTitle>
+            <CardDescription>Fill out the following fields to create a new device.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <NewDeviceForm
+              types={createSelectFieldItems(types.data)}
+              statuses={createSelectFieldItems(statuses.data)}
+              groups={createSelectFieldItems(groups.data)}
+            />
+          </CardContent>
+          <CardFooter className="justify-end gap-2">
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+            <Button form={FORM_ID} type="submit">
+              Create Device
+            </Button>
+          </CardFooter>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from "react";
 
+import type { Metadata } from "next";
+
 import { getDeviceTypes } from "@/dal/type";
 
 import { getDeviceGroups } from "@/dal/group";
@@ -8,7 +10,7 @@ import { getDeviceStatuses } from "@/dal/status";
 
 import { validatePageSize } from "@/features/device/lib/utils";
 
-import { DEFAULT_PAGE } from "@/features/device/lib/constants";
+import { DEFAULT_PAGE, DEVICES_DESCRIPTION, DEVICES_TITLE } from "@/features/device/lib/constants";
 
 import { ButtonGroup } from "@/components/ui/button-group";
 
@@ -41,6 +43,11 @@ type DevicesPageProps = {
     sortBy?: string;
     sortDirection?: string;
   }>;
+};
+
+export const metadata: Metadata = {
+  title: DEVICES_TITLE,
+  description: DEVICES_DESCRIPTION,
 };
 
 export default async function DevicesPage({ searchParams }: DevicesPageProps) {

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 
+import { APP_NAME } from "@/lib/constants";
+
 import { DASHBOARD_DESC, DASHBOARD_TITLE } from "@/features/dashboard/lib/constants";
 
 import Sidebar from "@/features/dashboard/components/sidebar";
@@ -9,7 +11,10 @@ type LayoutProps = {
 };
 
 export const metadata: Metadata = {
-  title: DASHBOARD_TITLE,
+  title: {
+    template: `%s | ${APP_NAME}`,
+    default: DASHBOARD_TITLE,
+  },
   description: DASHBOARD_DESC,
 };
 

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 import { APP_NAME } from "@/lib/constants";
 
-import { DASHBOARD_DESC, DASHBOARD_TITLE } from "@/features/dashboard/lib/constants";
+import { DASHBOARD_DESCRIPTION, DASHBOARD_TITLE } from "@/features/dashboard/lib/constants";
 
 import Sidebar from "@/features/dashboard/components/sidebar";
 
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     template: `%s | ${APP_NAME}`,
     default: DASHBOARD_TITLE,
   },
-  description: DASHBOARD_DESC,
+  description: DASHBOARD_DESCRIPTION,
 };
 
 export default function DashboardLayout({ children }: LayoutProps) {

--- a/src/features/dashboard/lib/constants.ts
+++ b/src/features/dashboard/lib/constants.ts
@@ -10,6 +10,6 @@ export const AVATAR_FALLBACK_DELAY = 600;
 
 export const DASHBOARD_TITLE = "Dashboard";
 
-export const DASHBOARD_DESC = "An overview of your devices, location device data, and health status.";
+export const DASHBOARD_DESCRIPTION = "An overview of your devices, location device data, and health status.";
 
 export const TIMER_IN_MILLISECONDS = 1500;

--- a/src/features/dashboard/lib/constants.ts
+++ b/src/features/dashboard/lib/constants.ts
@@ -4,6 +4,8 @@ export const DEVICES_PATH = "/devices";
 
 export const PROFILE_PATH = `${DASHBOARD_PATH}/profile`;
 
+export const NEW_DEVICE_PATH = `${DEVICES_PATH}/new`;
+
 export const AVATAR_FALLBACK_DELAY = 600;
 
 export const DASHBOARD_TITLE = "Dashboard";

--- a/src/features/device/components/button-actions.tsx
+++ b/src/features/device/components/button-actions.tsx
@@ -1,8 +1,12 @@
-import { ButtonGroup } from "@/components/ui/button-group";
+import Link from "next/link";
 
-import { Button, buttonVariants } from "@/components/ui/button";
+import { DownloadCloudIcon, ImportIcon, MoreHorizontalIcon, PlusIcon } from "lucide-react";
 
-import { ChevronDownIcon, DownloadCloudIcon, ImportIcon, PlusIcon } from "lucide-react";
+import { NEW_DEVICE_PATH } from "@/features/dashboard/lib/constants";
+
+import { buttonVariants } from "@/components/ui/button";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import {
   DropdownMenu,
@@ -13,15 +17,24 @@ import {
 
 export default function ButtonActions() {
   return (
-    <ButtonGroup aria-label="Button Actions Group">
-      <Button type="button">
-        <PlusIcon />
-        New Device
-      </Button>
+    <div className="flex items-center gap-1">
+      <NewDeviceLink />
       <DropdownMenu>
-        <DropdownMenuTrigger aria-label="More Options" className={buttonVariants({ size: "icon" })}>
-          <ChevronDownIcon />
-        </DropdownMenuTrigger>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <DropdownMenuTrigger
+                aria-label="More Options"
+                className={buttonVariants({ variant: "outline", size: "icon" })}
+              >
+                <MoreHorizontalIcon />
+              </DropdownMenuTrigger>
+            }
+          />
+          <TooltipContent>
+            <p>More options</p>
+          </TooltipContent>
+        </Tooltip>
         <DropdownMenuContent align="end" className="w-40">
           <DropdownMenuItem>
             <DownloadCloudIcon />
@@ -33,6 +46,15 @@ export default function ButtonActions() {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-    </ButtonGroup>
+    </div>
+  );
+}
+
+function NewDeviceLink() {
+  return (
+    <Link href={NEW_DEVICE_PATH} className={buttonVariants()}>
+      <PlusIcon />
+      New Device
+    </Link>
   );
 }

--- a/src/features/device/components/new-device-card.tsx
+++ b/src/features/device/components/new-device-card.tsx
@@ -50,6 +50,8 @@ export default function NewDeviceCard({ types, statuses, groups }: NewDeviceForm
 
   const [state, formAction, isFormPending] = useActionState(createDevice, null);
 
+  const isButtonDisabled = !types?.length || !statuses?.length || !groups?.length || isFormPending;
+
   useFormSuccess(state?.success, () => {
     push(DEVICES_PATH);
     toast.success(ACTION_MESSAGE.created);
@@ -109,7 +111,7 @@ export default function NewDeviceCard({ types, statuses, groups }: NewDeviceForm
         >
           Cancel
         </Link>
-        <Button form={FORM_ID} type="submit" disabled={isFormPending}>
+        <Button form={FORM_ID} type="submit" disabled={isButtonDisabled}>
           Create Device
         </Button>
       </CardFooter>

--- a/src/features/device/components/new-device-card.tsx
+++ b/src/features/device/components/new-device-card.tsx
@@ -2,17 +2,23 @@
 
 import Link from "next/link";
 
+import { toast } from "sonner";
+
 import { useActionState } from "react";
+
+import { useRouter } from "next/navigation";
 
 import { createDevice } from "@/features/device/lib/actions";
 
 import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
 
-import { FORM_FIELD, FORM_ID } from "@/features/device/lib/constants";
+import { ACTION_MESSAGE, FORM_FIELD, FORM_ID } from "@/features/device/lib/constants";
 
 import type { SelectFieldItem } from "@/features/device/lib/definitions";
 
 import useFields from "@/features/device/hooks/use-fields";
+
+import useFormSuccess from "@/features/device/hooks/use-form-success";
 
 import { Input } from "@/components/ui/input";
 
@@ -40,7 +46,14 @@ export default function NewDeviceCard({ types, statuses, groups }: NewDeviceForm
     ipAddress: "",
   });
 
+  const { push } = useRouter();
+
   const [state, formAction, isFormPending] = useActionState(createDevice, null);
+
+  useFormSuccess(state?.success, () => {
+    push(DEVICES_PATH);
+    toast.success(ACTION_MESSAGE.created);
+  });
 
   return (
     <Card>

--- a/src/features/device/components/new-device-card.tsx
+++ b/src/features/device/components/new-device-card.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import Link from "next/link";
+
 import { useActionState } from "react";
 
 import { createDevice } from "@/features/device/lib/actions";
+
+import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
 
 import { FORM_FIELD, FORM_ID } from "@/features/device/lib/constants";
 
@@ -12,7 +16,11 @@ import useFields from "@/features/device/hooks/use-fields";
 
 import { Input } from "@/components/ui/input";
 
+import { Button, buttonVariants } from "@/components/ui/button";
+
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
@@ -22,7 +30,7 @@ type NewDeviceFormProps = {
   groups?: SelectFieldItem[];
 };
 
-export default function NewDeviceForm({ types, statuses, groups }: NewDeviceFormProps) {
+export default function NewDeviceCard({ types, statuses, groups }: NewDeviceFormProps) {
   const { field, handleFieldChange } = useFields({
     name: "",
     typeId: "",
@@ -32,46 +40,67 @@ export default function NewDeviceForm({ types, statuses, groups }: NewDeviceForm
     ipAddress: "",
   });
 
-  const [state, formAction] = useActionState(createDevice, null);
+  const [state, formAction, isFormPending] = useActionState(createDevice, null);
 
   return (
-    <form id={FORM_ID} action={formAction}>
-      <FieldGroup>
-        <NameField
-          value={field.name}
-          error={state?.serverErrors?.name}
-          onFieldChange={(value) => handleFieldChange("name", value)}
-        />
-        <TypeField
-          items={types}
-          value={field.typeId}
-          error={state?.serverErrors?.typeId}
-          onFieldChange={(value) => handleFieldChange("typeId", value)}
-        />
-        <StatusField
-          items={statuses}
-          value={field.statusId}
-          error={state?.serverErrors?.statusId}
-          onFieldChange={(value) => handleFieldChange("statusId", value)}
-        />
-        <GroupField
-          items={groups}
-          value={field.groupId}
-          error={state?.serverErrors?.groupId}
-          onFieldChange={(value) => handleFieldChange("groupId", value)}
-        />
-        <SerialNumberField
-          value={field.serialNumber}
-          error={state?.serverErrors?.serialNumber}
-          onFieldChange={(value) => handleFieldChange("serialNumber", value)}
-        />
-        <IpAddressField
-          value={field.ipAddress}
-          error={state?.serverErrors?.ipAddress}
-          onFieldChange={(value) => handleFieldChange("ipAddress", value)}
-        />
-      </FieldGroup>
-    </form>
+    <Card>
+      <CardHeader>
+        <CardTitle>Device Information</CardTitle>
+        <CardDescription>Fill out the following fields to create a new device.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form id={FORM_ID} action={formAction}>
+          <FieldGroup>
+            <NameField
+              value={field.name}
+              error={state?.serverErrors?.name}
+              onFieldChange={(value) => handleFieldChange("name", value)}
+            />
+            <TypeField
+              items={types}
+              value={field.typeId}
+              error={state?.serverErrors?.typeId}
+              onFieldChange={(value) => handleFieldChange("typeId", value)}
+            />
+            <StatusField
+              items={statuses}
+              value={field.statusId}
+              error={state?.serverErrors?.statusId}
+              onFieldChange={(value) => handleFieldChange("statusId", value)}
+            />
+            <GroupField
+              items={groups}
+              value={field.groupId}
+              error={state?.serverErrors?.groupId}
+              onFieldChange={(value) => handleFieldChange("groupId", value)}
+            />
+            <SerialNumberField
+              value={field.serialNumber}
+              error={state?.serverErrors?.serialNumber}
+              onFieldChange={(value) => handleFieldChange("serialNumber", value)}
+            />
+            <IpAddressField
+              value={field.ipAddress}
+              error={state?.serverErrors?.ipAddress}
+              onFieldChange={(value) => handleFieldChange("ipAddress", value)}
+            />
+          </FieldGroup>
+        </form>
+      </CardContent>
+      <CardFooter className="justify-end gap-2">
+        <Link
+          href={DEVICES_PATH}
+          aria-disabled={isFormPending}
+          tabIndex={isFormPending ? -1 : undefined}
+          className={buttonVariants({ variant: "outline", className: isFormPending ? "pointer-events-none" : "" })}
+        >
+          Cancel
+        </Link>
+        <Button form={FORM_ID} type="submit" disabled={isFormPending}>
+          Create Device
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }
 

--- a/src/features/device/components/new-device-form.tsx
+++ b/src/features/device/components/new-device-form.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { useActionState } from "react";
+
+import { createDevice } from "@/features/device/lib/actions";
+
 import { FORM_FIELD, FORM_ID } from "@/features/device/lib/constants";
 
 import type { SelectFieldItem } from "@/features/device/lib/definitions";
@@ -28,26 +32,44 @@ export default function NewDeviceForm({ types, statuses, groups }: NewDeviceForm
     ipAddress: "",
   });
 
+  const [state, formAction] = useActionState(createDevice, null);
+
   return (
-    <form id={FORM_ID} onSubmit={(e) => e.preventDefault()}>
+    <form id={FORM_ID} action={formAction}>
       <FieldGroup>
-        <NameField value={field.name} onFieldChange={(value) => handleFieldChange("name", value)} />
-        <TypeField items={types} value={field.typeId} onFieldChange={(value) => handleFieldChange("typeId", value)} />
+        <NameField
+          value={field.name}
+          error={state?.serverErrors?.name}
+          onFieldChange={(value) => handleFieldChange("name", value)}
+        />
+        <TypeField
+          items={types}
+          value={field.typeId}
+          error={state?.serverErrors?.typeId}
+          onFieldChange={(value) => handleFieldChange("typeId", value)}
+        />
         <StatusField
           items={statuses}
           value={field.statusId}
+          error={state?.serverErrors?.statusId}
           onFieldChange={(value) => handleFieldChange("statusId", value)}
         />
         <GroupField
           items={groups}
           value={field.groupId}
+          error={state?.serverErrors?.groupId}
           onFieldChange={(value) => handleFieldChange("groupId", value)}
         />
         <SerialNumberField
           value={field.serialNumber}
+          error={state?.serverErrors?.serialNumber}
           onFieldChange={(value) => handleFieldChange("serialNumber", value)}
         />
-        <IpAddressField value={field.ipAddress} onFieldChange={(value) => handleFieldChange("ipAddress", value)} />
+        <IpAddressField
+          value={field.ipAddress}
+          error={state?.serverErrors?.ipAddress}
+          onFieldChange={(value) => handleFieldChange("ipAddress", value)}
+        />
       </FieldGroup>
     </form>
   );

--- a/src/features/device/components/new-device-form.tsx
+++ b/src/features/device/components/new-device-form.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { FORM_FIELD, FORM_ID } from "@/features/device/lib/constants";
+
+import type { SelectFieldItem } from "@/features/device/lib/definitions";
+
+import useFields from "@/features/device/hooks/use-fields";
+
+import { Input } from "@/components/ui/input";
+
+import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+type NewDeviceFormProps = {
+  types?: SelectFieldItem[];
+  statuses?: SelectFieldItem[];
+  groups?: SelectFieldItem[];
+};
+
+export default function NewDeviceForm({ types, statuses, groups }: NewDeviceFormProps) {
+  const { field, handleFieldChange } = useFields({
+    name: "",
+    typeId: "",
+    statusId: "",
+    groupId: "",
+    serialNumber: "",
+    ipAddress: "",
+  });
+
+  return (
+    <form id={FORM_ID} onSubmit={(e) => e.preventDefault()}>
+      <FieldGroup>
+        <NameField value={field.name} onFieldChange={(value) => handleFieldChange("name", value)} />
+        <TypeField items={types} value={field.typeId} onFieldChange={(value) => handleFieldChange("typeId", value)} />
+        <StatusField
+          items={statuses}
+          value={field.statusId}
+          onFieldChange={(value) => handleFieldChange("statusId", value)}
+        />
+        <GroupField
+          items={groups}
+          value={field.groupId}
+          onFieldChange={(value) => handleFieldChange("groupId", value)}
+        />
+        <SerialNumberField
+          value={field.serialNumber}
+          onFieldChange={(value) => handleFieldChange("serialNumber", value)}
+        />
+        <IpAddressField value={field.ipAddress} onFieldChange={(value) => handleFieldChange("ipAddress", value)} />
+      </FieldGroup>
+    </form>
+  );
+}
+
+type FieldProps = {
+  value: string;
+  error?: string;
+  items?: SelectFieldItem[];
+  onFieldChange: (value: string) => void;
+};
+
+function NameField({ value, error, onFieldChange }: FieldProps) {
+  return (
+    <Field>
+      <FieldLabel htmlFor={FORM_FIELD.NAME.id}>
+        Name <span className="text-destructive">*</span>
+      </FieldLabel>
+      <Input
+        id={FORM_FIELD.NAME.id}
+        type="text"
+        name={FORM_FIELD.NAME.id}
+        placeholder={FORM_FIELD.NAME.placeholder}
+        autoComplete="off"
+        value={value}
+        onChange={(e) => onFieldChange(e.target.value)}
+        required
+      />
+      <FieldError>{error}</FieldError>
+    </Field>
+  );
+}
+
+function TypeField({ items, value, error, onFieldChange }: FieldProps) {
+  return (
+    <Field>
+      <FieldLabel htmlFor={FORM_FIELD.TYPE.id}>
+        Type <span className="text-destructive">*</span>
+      </FieldLabel>
+      <Select
+        id={FORM_FIELD.TYPE.id}
+        name={FORM_FIELD.TYPE.id}
+        items={items}
+        value={value}
+        onValueChange={(value) => onFieldChange(value ?? "")}
+        disabled={!items?.length}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder={FORM_FIELD.TYPE.placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {items?.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <FieldError>{error}</FieldError>
+    </Field>
+  );
+}
+
+function StatusField({ items, value, error, onFieldChange }: FieldProps) {
+  return (
+    <Field>
+      <FieldLabel htmlFor={FORM_FIELD.STATUS.id}>
+        Status <span className="text-destructive">*</span>
+      </FieldLabel>
+      <Select
+        id={FORM_FIELD.STATUS.id}
+        name={FORM_FIELD.STATUS.id}
+        items={items}
+        value={value}
+        onValueChange={(value) => onFieldChange(value ?? "")}
+        disabled={!items?.length}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder={FORM_FIELD.STATUS.placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {items?.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <FieldError>{error}</FieldError>
+    </Field>
+  );
+}
+
+function GroupField({ items, value, error, onFieldChange }: FieldProps) {
+  return (
+    <Field>
+      <FieldLabel htmlFor={FORM_FIELD.GROUP.id}>
+        Group <span className="text-destructive">*</span>
+      </FieldLabel>
+      <Select
+        id={FORM_FIELD.GROUP.id}
+        name={FORM_FIELD.GROUP.id}
+        items={items}
+        value={value}
+        onValueChange={(value) => onFieldChange(value ?? "")}
+        disabled={!items?.length}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder={FORM_FIELD.GROUP.placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {items?.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <FieldError>{error}</FieldError>
+    </Field>
+  );
+}
+
+function SerialNumberField({ value, error, onFieldChange }: FieldProps) {
+  return (
+    <Field>
+      <FieldLabel htmlFor={FORM_FIELD.SERIAL_NUMBER.id}>
+        Serial Number <span className="text-destructive">*</span>
+      </FieldLabel>
+      <Input
+        id={FORM_FIELD.SERIAL_NUMBER.id}
+        type="text"
+        name={FORM_FIELD.SERIAL_NUMBER.id}
+        placeholder={FORM_FIELD.SERIAL_NUMBER.placeholder}
+        autoComplete="off"
+        value={value}
+        onChange={(e) => onFieldChange(e.target.value)}
+        required
+      />
+      <FieldError>{error}</FieldError>
+    </Field>
+  );
+}
+
+function IpAddressField({ value, error, onFieldChange }: FieldProps) {
+  return (
+    <Field>
+      <FieldLabel htmlFor={FORM_FIELD.IP_ADDRESS.id}>IP Address</FieldLabel>
+      <Input
+        id={FORM_FIELD.IP_ADDRESS.id}
+        type="text"
+        name={FORM_FIELD.IP_ADDRESS.id}
+        placeholder={FORM_FIELD.IP_ADDRESS.placeholder}
+        autoComplete="off"
+        value={value}
+        onChange={(e) => onFieldChange(e.target.value)}
+      />
+      <FieldError>{error}</FieldError>
+    </Field>
+  );
+}

--- a/src/features/device/hooks/use-fields.tsx
+++ b/src/features/device/hooks/use-fields.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 
 type UseFieldsProps<T> = { [K in keyof T]: T[K] };
 
-export default function useField<T>(initialState: UseFieldsProps<T>) {
+export default function useFields<T>(initialState: UseFieldsProps<T>) {
   const [field, setField] = useState(initialState);
 
   const handleFieldChange = (name: keyof typeof field, value: T[keyof T]) => {

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 
 import { and, eq, sql } from "drizzle-orm";
 
+import { redirect } from "next/navigation";
+
 import { revalidatePath } from "next/cache";
 
 import { db } from "@/db/client";
@@ -12,11 +14,15 @@ import { getSession } from "@/dal/session";
 
 import { devicesTable } from "@/db/schemas";
 
+import { generateId } from "@/lib/utils";
+
 import type { ActionReturnType } from "@/lib/definitions";
 
 import type { Device } from "@/features/device/lib/definitions";
 
-import { DeleteDeviceSchema, EditDeviceSchema, MoveDeviceSchema } from "@/features/device/lib/schemas";
+import { DASHBOARD_PATH, DEVICES_PATH } from "@/features/dashboard/lib/constants";
+
+import { DeleteDeviceSchema, EditDeviceSchema, MoveDeviceSchema, NewDeviceSchema } from "@/features/device/lib/schemas";
 
 type EditDeviceAction = ActionReturnType<Partial<Omit<Device, "id">> & { ipAddress?: string }>;
 
@@ -160,4 +166,59 @@ export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
     success: true,
     serverErrors: null,
   };
+};
+
+export const createDevice = async (_prevState: unknown, formData: FormData) => {
+  const { userId } = await getSession();
+
+  const parsedFields = NewDeviceSchema.safeParse({
+    name: formData.get("name")?.toString().trim(),
+    typeId: formData.get("type-id")?.toString().trim(),
+    statusId: formData.get("status-id")?.toString().trim(),
+    groupId: formData.get("group-id")?.toString().trim(),
+    serialNumber: formData.get("serial-number")?.toString().trim(),
+    ipAddress: formData.get("ip-address")?.toString().trim(),
+  });
+
+  try {
+    if (!parsedFields.success) {
+      const { fieldErrors } = z.flattenError(parsedFields.error);
+
+      return {
+        success: false,
+        serverErrors: {
+          name: fieldErrors.name?.toString(),
+          typeId: fieldErrors.typeId?.toString(),
+          statusId: fieldErrors.statusId?.toString(),
+          groupId: fieldErrors.groupId?.toString(),
+          serialNumber: fieldErrors.serialNumber?.toString(),
+          ipAddress: fieldErrors.ipAddress?.toString(),
+        },
+      };
+    }
+
+    await db.transaction(async (tx) => {
+      await tx.insert(devicesTable).values({
+        id: generateId(),
+        name: parsedFields.data.name,
+        userId,
+        typeId: parsedFields.data.typeId,
+        statusId: parsedFields.data.statusId,
+        groupId: parsedFields.data.groupId,
+        serialNumber: parsedFields.data.serialNumber,
+        ipAddress: parsedFields.data.ipAddress,
+      });
+    });
+  } catch {
+    return {
+      success: false,
+      serverErrors: {
+        ipAddress: "A server error has occurred.",
+      },
+    };
+  }
+
+  revalidatePath(DASHBOARD_PATH);
+  revalidatePath(DEVICES_PATH);
+  redirect(DEVICES_PATH);
 };

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -4,8 +4,6 @@ import { z } from "zod";
 
 import { and, eq, sql } from "drizzle-orm";
 
-import { redirect } from "next/navigation";
-
 import { revalidatePath } from "next/cache";
 
 import { db } from "@/db/client";
@@ -220,5 +218,8 @@ export const createDevice = async (_prevState: unknown, formData: FormData) => {
 
   revalidatePath(DASHBOARD_PATH);
   revalidatePath(DEVICES_PATH);
-  redirect(DEVICES_PATH);
+
+  return {
+    success: true,
+  };
 };

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -32,3 +32,7 @@ export const PAGE_SIZE_PARAM_ID = "pageSize";
 export const DEFAULT_PAGE = 1;
 
 export const DEFAULT_PAGE_SIZE = PAGE_SIZES[0];
+
+export const DEVICES_TITLE = "Devices";
+
+export const DEVICES_DESCRIPTION = "View, filter, and manage your devices.";

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -12,7 +12,7 @@ export const FORM_FIELD = {
 };
 
 export const ACTION_MESSAGE = {
-  created: null,
+  created: "The device was successfully created.",
   updated: "The device was successfully updated.",
   moved: "The device was successfully moved.",
   deleted: "The device was successfully deleted.",

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -36,3 +36,7 @@ export const DEFAULT_PAGE_SIZE = PAGE_SIZES[0];
 export const DEVICES_TITLE = "Devices";
 
 export const DEVICES_DESCRIPTION = "View, filter, and manage your devices.";
+
+export const NEW_DEVICE_TITLE = "Add New Device";
+
+export const NEW_DEVICE_DESCRIPTION = "Add a new device to your account.";

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -2,6 +2,15 @@ export const TABLE_COLUMNS = ["Name", "Type", "Status", "Group", "Serial Number"
 
 export const FORM_ID = "device-form";
 
+export const FORM_FIELD = {
+  NAME: { id: "name", placeholder: "John's MacBook Pro" },
+  TYPE: { id: "type-id", placeholder: "Select a type" },
+  STATUS: { id: "status-id", placeholder: "Select a group" },
+  GROUP: { id: "group-id", placeholder: "Select a status" },
+  SERIAL_NUMBER: { id: "serial-number", placeholder: "SN-LTP-1001" },
+  IP_ADDRESS: { id: "ip-address", placeholder: "192.168.1.10" },
+};
+
 export const ACTION_MESSAGE = {
   created: null,
   updated: "The device was successfully updated.",

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -25,3 +25,8 @@ export type BaseDeviceModalProps<T = object> = {
 } & T;
 
 export type SortDirection = "asc" | "desc";
+
+export type SelectFieldItem = {
+  label: string;
+  value: string;
+};

--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -4,6 +4,8 @@ import { camelCase } from "@/lib/utils";
 
 import type { Options } from "@/lib/definitions";
 
+import type { DeviceType } from "@/features/device/lib/definitions";
+
 import { deviceGroupsTable, devicesTable, deviceStatusesTable, deviceTypesTable } from "@/db/schemas";
 
 const getTableColumn = (column: string) => {
@@ -73,4 +75,10 @@ export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {
   });
 
   return query;
+};
+
+export const createSelectFieldItems = (items: DeviceType[] | null) => {
+  if (items) {
+    return items.map((item) => ({ label: item.name, value: item.id }));
+  }
 };

--- a/src/features/device/lib/schemas.ts
+++ b/src/features/device/lib/schemas.ts
@@ -14,3 +14,5 @@ export const MoveDeviceSchema = EditDeviceSchema.pick({
 });
 
 export const DeleteDeviceSchema = z.string();
+
+export const NewDeviceSchema = EditDeviceSchema;

--- a/src/features/device/lib/schemas.ts
+++ b/src/features/device/lib/schemas.ts
@@ -4,7 +4,7 @@ export const EditDeviceSchema = z.object({
   name: z.string().min(1, "Name is required.").max(255, "Name is too long."),
   typeId: z.string().min(1, "Type is required.").max(255, "Type is too long."),
   statusId: z.string().min(1, "Status is required.").max(255, "Status is too long."),
-  groupId: z.string().min(1, "Group is required").max(255, "Group is too long."),
+  groupId: z.string().min(1, "Group is required.").max(255, "Group is too long."),
   serialNumber: z.string().min(1, "Serial number is required.").max(64, "Serial Number is too long."),
   ipAddress: z.union([z.string().max(0), z.ipv4()], "Invalid IP address."),
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,8 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export const generateId = () => crypto.randomUUID().replaceAll("-", "");
+
 export const camelCase = (value: string) => {
   return value
     .split(" ")


### PR DESCRIPTION
This PR introduces a new page that allows users to create a new device.

## Changes
- Built the new device page.
- Built the form that allows the submission of creating a new device.
- Built the `createDevice` action.
- Added metadata to the devices page.
- Added metadata to the new device page.
- Renamed the hook `useField` to `useFields`.
- Renamed the constant `DASHBOARD_DESC` to `DASHBOARD_DESCRIPTION`.
- Added a `.` to the `groupId` error message.
- Updated the created action message.