### PR TITLE
Feature/device details page

### DIFF
--- a/src/app/(dashboard)/devices/[id]/loading.tsx
+++ b/src/app/(dashboard)/devices/[id]/loading.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="mx-auto flex flex-col gap-5 py-5 md:max-w-xl">
+      <div className="flex justify-between">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-8 w-8" />
+      </div>
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="flex gap-4 border p-4">
+        <Skeleton className="h-12 w-12" />
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-5 w-24" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-4 border p-4">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-4 w-56" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/devices/[id]/page.tsx
+++ b/src/app/(dashboard)/devices/[id]/page.tsx
@@ -6,6 +6,8 @@ import { ChevronRightIcon, MonitorSmartphoneIcon, MoreHorizontalIcon } from "luc
 
 import { getDeviceById } from "@/dal/device";
 
+import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
+
 import { NOT_FOUND_DESCRIPTION, NOT_FOUND_TITLE } from "@/lib/constants";
 
 import { getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
@@ -68,7 +70,7 @@ export default async function DevicePage({ params }: DevicePageProps) {
           <nav>
             <ol className="flex items-center gap-2 text-sm">
               <li>
-                <Link href="/devices" className="text-muted-foreground">
+                <Link href={DEVICES_PATH} className="text-muted-foreground">
                   Devices
                 </Link>
               </li>

--- a/src/app/(dashboard)/devices/[id]/page.tsx
+++ b/src/app/(dashboard)/devices/[id]/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+
+import { ChevronRightIcon, MonitorSmartphoneIcon, MoreHorizontalIcon } from "lucide-react";
+
+import devicesJson from "@/lib/data/devices.json";
+
+import { getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
+
+import { Badge } from "@/components/ui/badge";
+
+import { Button } from "@/components/ui/button";
+
+import { ButtonGroup } from "@/components/ui/button-group";
+
+import { Header, HeaderTitle } from "@/features/dashboard/components/header";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default async function DevicePage() {
+  const device = devicesJson[0];
+
+  const deviceInfoItems = [
+    { label: "Type", value: device.device_type },
+    { label: "Group", value: device.device_group },
+    { label: "Serial Number", value: device.serial_number },
+    { label: "IP Address", value: device.ip_address },
+  ];
+
+  return (
+    <div className="mx-auto md:max-w-xl">
+      <Header>
+        <HeaderTitle>Device Details</HeaderTitle>
+      </Header>
+      <main className="flex flex-col gap-5 pb-5">
+        <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+          <nav>
+            <ol className="flex items-center gap-2 text-sm">
+              <li>
+                <Link href="/devices" className="text-muted-foreground">
+                  Devices
+                </Link>
+              </li>
+              <li>
+                <ChevronRightIcon className="text-muted-foreground size-3.5" />
+              </li>
+              <li className="max-w-60">
+                <span className="truncate">{device.name}</span>
+              </li>
+            </ol>
+          </nav>
+          <ButtonGroup>
+            <Button type="button" variant="outline">
+              Edit Device
+            </Button>
+            <Button type="button" variant="outline" size="icon">
+              <MoreHorizontalIcon />
+            </Button>
+          </ButtonGroup>
+        </div>
+        <article>
+          <Card className="flex-row items-center gap-0">
+            <div className="pl-3">
+              <div className="bg-accent flex h-12 w-12 items-center justify-center">
+                <MonitorSmartphoneIcon />
+              </div>
+            </div>
+            <div className="flex w-full flex-col gap-2">
+              <CardHeader>
+                <CardTitle>{device.name}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Badge className={getBadgeIconColorClassesByStatus(device.device_status.toLowerCase())}>
+                  {device.device_status}
+                </Badge>
+              </CardContent>
+            </div>
+          </Card>
+        </article>
+        <article>
+          <Card>
+            <CardHeader>
+              <CardTitle>System Information</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="flex flex-col gap-2 text-sm">
+                {deviceInfoItems.map((deviceInfoItem) => (
+                  <li key={deviceInfoItem.value}>
+                    <strong className="font-medium">{deviceInfoItem.label}</strong>: {deviceInfoItem.value}
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        </article>
+      </main>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/devices/[id]/page.tsx
+++ b/src/app/(dashboard)/devices/[id]/page.tsx
@@ -1,8 +1,10 @@
 import Link from "next/link";
 
+import { notFound } from "next/navigation";
+
 import { ChevronRightIcon, MonitorSmartphoneIcon, MoreHorizontalIcon } from "lucide-react";
 
-import devicesJson from "@/lib/data/devices.json";
+import { getDeviceById } from "@/dal/device";
 
 import { getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
 
@@ -16,14 +18,24 @@ import { Header, HeaderTitle } from "@/features/dashboard/components/header";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-export default async function DevicePage() {
-  const device = devicesJson[0];
+type DevicePageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function DevicePage({ params }: DevicePageProps) {
+  const { id } = await params;
+
+  const { data, error } = await getDeviceById(id);
+
+  if (!data || error) {
+    notFound();
+  }
 
   const deviceInfoItems = [
-    { label: "Type", value: device.device_type },
-    { label: "Group", value: device.device_group },
-    { label: "Serial Number", value: device.serial_number },
-    { label: "IP Address", value: device.ip_address },
+    { label: "Type", value: data.type },
+    { label: "Group", value: data.group },
+    { label: "Serial Number", value: data.serialNumber },
+    { label: "IP Address", value: data.ipAddress },
   ];
 
   return (
@@ -44,7 +56,7 @@ export default async function DevicePage() {
                 <ChevronRightIcon className="text-muted-foreground size-3.5" />
               </li>
               <li className="max-w-60">
-                <span className="truncate">{device.name}</span>
+                <span className="truncate">{data.name}</span>
               </li>
             </ol>
           </nav>
@@ -66,12 +78,10 @@ export default async function DevicePage() {
             </div>
             <div className="flex w-full flex-col gap-2">
               <CardHeader>
-                <CardTitle>{device.name}</CardTitle>
+                <CardTitle>{data.name}</CardTitle>
               </CardHeader>
               <CardContent>
-                <Badge className={getBadgeIconColorClassesByStatus(device.device_status.toLowerCase())}>
-                  {device.device_status}
-                </Badge>
+                <Badge className={getBadgeIconColorClassesByStatus(data.status.toLowerCase())}>{data.status}</Badge>
               </CardContent>
             </div>
           </Card>

--- a/src/app/(dashboard)/devices/[id]/page.tsx
+++ b/src/app/(dashboard)/devices/[id]/page.tsx
@@ -6,6 +6,8 @@ import { ChevronRightIcon, MonitorSmartphoneIcon, MoreHorizontalIcon } from "luc
 
 import { getDeviceById } from "@/dal/device";
 
+import { NOT_FOUND_DESCRIPTION, NOT_FOUND_TITLE } from "@/lib/constants";
+
 import { getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
 
 import { Badge } from "@/components/ui/badge";
@@ -20,6 +22,24 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 type DevicePageProps = {
   params: Promise<{ id: string }>;
+};
+
+export const generateMetadata = async ({ params }: DevicePageProps) => {
+  const { id } = await params;
+
+  const { data, error } = await getDeviceById(id);
+
+  if (!data || error) {
+    return {
+      title: NOT_FOUND_TITLE,
+      description: NOT_FOUND_DESCRIPTION,
+    };
+  }
+
+  return {
+    title: data.name,
+    description: `View and manage device information for ${data.name}.`,
+  };
 };
 
 export default async function DevicePage({ params }: DevicePageProps) {

--- a/src/app/(dashboard)/devices/[id]/page.tsx
+++ b/src/app/(dashboard)/devices/[id]/page.tsx
@@ -55,7 +55,7 @@ export default async function DevicePage({ params }: DevicePageProps) {
     { label: "Type", value: data.type },
     { label: "Group", value: data.group },
     { label: "Serial Number", value: data.serialNumber },
-    { label: "IP Address", value: data.ipAddress },
+    { label: "IP Address", value: data.ipAddress || "Not Assigned" },
   ];
 
   return (

--- a/src/app/(dashboard)/devices/[id]/page.tsx
+++ b/src/app/(dashboard)/devices/[id]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { notFound } from "next/navigation";
 
-import { ChevronRightIcon, MonitorSmartphoneIcon, MoreHorizontalIcon } from "lucide-react";
+import { ChevronRightIcon, MonitorSmartphoneIcon } from "lucide-react";
 
 import { getDeviceTypes } from "@/dal/type";
 
@@ -18,9 +18,9 @@ import { NOT_FOUND_DESCRIPTION, NOT_FOUND_TITLE } from "@/lib/constants";
 
 import { getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
 
-import { Badge } from "@/components/ui/badge";
+import { ModalProvider } from "@/features/device/providers/modal-provider";
 
-import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 
 import { ButtonGroup } from "@/components/ui/button-group";
 
@@ -29,6 +29,8 @@ import { Header, HeaderTitle } from "@/features/dashboard/components/header";
 import EditDeviceButton from "@/features/device/components/edit-device-button";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import DeviceActionsButton from "@/features/device/components/device-actions-button";
 
 type DevicePageProps = {
   params: Promise<{ id: string }>;
@@ -94,9 +96,9 @@ export default async function DevicePage({ params }: DevicePageProps) {
           </nav>
           <ButtonGroup>
             <EditDeviceButton device={data} types={types.data} statuses={statuses.data} groups={groups.data} />
-            <Button type="button" variant="outline" size="icon">
-              <MoreHorizontalIcon />
-            </Button>
+            <ModalProvider>
+              <DeviceActionsButton device={data} types={types.data} statuses={statuses.data} groups={groups.data} />
+            </ModalProvider>
           </ButtonGroup>
         </div>
         <article>

--- a/src/app/(dashboard)/devices/[id]/page.tsx
+++ b/src/app/(dashboard)/devices/[id]/page.tsx
@@ -4,7 +4,13 @@ import { notFound } from "next/navigation";
 
 import { ChevronRightIcon, MonitorSmartphoneIcon, MoreHorizontalIcon } from "lucide-react";
 
+import { getDeviceTypes } from "@/dal/type";
+
 import { getDeviceById } from "@/dal/device";
+
+import { getDeviceGroups } from "@/dal/group";
+
+import { getDeviceStatuses } from "@/dal/status";
 
 import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
 
@@ -19,6 +25,8 @@ import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 
 import { Header, HeaderTitle } from "@/features/dashboard/components/header";
+
+import EditDeviceButton from "@/features/device/components/edit-device-button";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -53,6 +61,8 @@ export default async function DevicePage({ params }: DevicePageProps) {
     notFound();
   }
 
+  const [types, statuses, groups] = await Promise.all([getDeviceTypes(), getDeviceStatuses(), getDeviceGroups()]);
+
   const deviceInfoItems = [
     { label: "Type", value: data.type },
     { label: "Group", value: data.group },
@@ -83,9 +93,7 @@ export default async function DevicePage({ params }: DevicePageProps) {
             </ol>
           </nav>
           <ButtonGroup>
-            <Button type="button" variant="outline">
-              Edit Device
-            </Button>
+            <EditDeviceButton device={data} types={types.data} statuses={statuses.data} groups={groups.data} />
             <Button type="button" variant="outline" size="icon">
               <MoreHorizontalIcon />
             </Button>

--- a/src/app/(dashboard)/devices/[id]/page.tsx
+++ b/src/app/(dashboard)/devices/[id]/page.tsx
@@ -95,8 +95,8 @@ export default async function DevicePage({ params }: DevicePageProps) {
             </ol>
           </nav>
           <ButtonGroup>
-            <EditDeviceButton device={data} types={types.data} statuses={statuses.data} groups={groups.data} />
             <ModalProvider>
+              <EditDeviceButton device={data} types={types.data} statuses={statuses.data} groups={groups.data} />
               <DeviceActionsButton device={data} types={types.data} statuses={statuses.data} groups={groups.data} />
             </ModalProvider>
           </ButtonGroup>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+import type { Metadata } from "next";
+
+import { HOME_PATH, NOT_FOUND_DESCRIPTION, NOT_FOUND_TITLE } from "@/lib/constants";
+
+import { buttonVariants } from "@/components/ui/button";
+
+import NotFoundMessage from "@/components/not-found-message";
+
+export const metadata: Metadata = {
+  title: NOT_FOUND_TITLE,
+  description: NOT_FOUND_DESCRIPTION,
+};
+
+export default function NotFound() {
+  return (
+    <div className="mx-auto w-full max-w-xl px-5">
+      <header className="py-5">
+        <h1 className="font-semibold">{NOT_FOUND_TITLE}</h1>
+      </header>
+      <main>
+        <NotFoundMessage />
+        <Link href={HOME_PATH} className={buttonVariants({ className: "mb-5" })}>
+          Go back to the home page
+        </Link>
+      </main>
+    </div>
+  );
+}

--- a/src/components/not-found-message.tsx
+++ b/src/components/not-found-message.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+export default function NotFoundMessage() {
+  const pathname = usePathname();
+
+  return (
+    <p className="mb-5 text-sm">
+      The resource <code className="bg-accent rounded px-1.5 py-0.5">{pathname}</code> was not found.
+    </p>
+  );
+}

--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -130,6 +130,9 @@ export const getDeviceById = async (deviceId: string) => {
     const data = await db
       .select({
         id: devicesTable.id,
+        typeId: devicesTable.typeId,
+        statusId: devicesTable.statusId,
+        groupId: devicesTable.groupId,
         type: deviceTypesTable.name,
         status: deviceStatusesTable.name,
         group: deviceGroupsTable.name,

--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { count, eq, ilike, sql } from "drizzle-orm";
+import { and, count, eq, ilike, sql } from "drizzle-orm";
 
 import { db } from "@/db/client";
 
@@ -119,6 +119,40 @@ export const getDevicesPages = async (options: Pick<Options, "pagination" | "fil
     return {
       data: null,
       error: "Failed to load data.",
+    };
+  }
+};
+
+export const getDeviceById = async (deviceId: string) => {
+  try {
+    const session = await getSession();
+
+    const data = await db
+      .select({
+        id: devicesTable.id,
+        type: deviceTypesTable.name,
+        status: deviceStatusesTable.name,
+        group: deviceGroupsTable.name,
+        name: devicesTable.name,
+        serialNumber: devicesTable.serialNumber,
+        ipAddress: devicesTable.ipAddress,
+      })
+      .from(devicesTable)
+      .innerJoin(deviceTypesTable, eq(devicesTable.typeId, deviceTypesTable.id))
+      .innerJoin(deviceStatusesTable, eq(devicesTable.statusId, deviceStatusesTable.id))
+      .innerJoin(deviceGroupsTable, eq(devicesTable.groupId, deviceGroupsTable.id))
+      .where(and(eq(devicesTable.userId, session.userId), eq(devicesTable.id, deviceId.toLowerCase())));
+
+    if (!data.length) throw new Error();
+
+    return {
+      data: data[0],
+      error: null,
+    };
+  } catch {
+    return {
+      data: null,
+      error: "Failed to get device.",
     };
   }
 };

--- a/src/features/device/components/delete-device-modal.tsx
+++ b/src/features/device/components/delete-device-modal.tsx
@@ -4,9 +4,13 @@ import { toast } from "sonner";
 
 import { useState, useTransition } from "react";
 
+import { usePathname, useRouter } from "next/navigation";
+
 import { deleteDevice } from "@/features/device/lib/actions";
 
 import { ACTION_MESSAGE } from "@/features/device/lib/constants";
+
+import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
 
 import type { BaseDeviceModalProps } from "@/features/device/lib/definitions";
 
@@ -24,6 +28,10 @@ import {
 type DeleteDeviceModalProps = BaseDeviceModalProps & { deviceName: string };
 
 export default function DeleteDeviceModal({ deviceId, deviceName, onClose }: DeleteDeviceModalProps) {
+  const pathname = usePathname();
+
+  const { replace } = useRouter();
+
   const [isPending, startTransition] = useTransition();
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -33,7 +41,10 @@ export default function DeleteDeviceModal({ deviceId, deviceName, onClose }: Del
       const { success, serverErrors } = await deleteDevice(deviceId);
 
       if (success) {
-        onClose();
+        const isDevicePath = pathname === `${DEVICES_PATH}/${deviceId}`;
+
+        if (isDevicePath) replace(DEVICES_PATH);
+        else onClose();
 
         setTimeout(() => {
           toast.success(ACTION_MESSAGE.deleted);

--- a/src/features/device/components/delete-device-modal.tsx
+++ b/src/features/device/components/delete-device-modal.tsx
@@ -33,7 +33,11 @@ export default function DeleteDeviceModal({ deviceId, deviceName, onClose }: Del
       const { success, serverErrors } = await deleteDevice(deviceId);
 
       if (success) {
-        toast.success(ACTION_MESSAGE.deleted);
+        onClose();
+
+        setTimeout(() => {
+          toast.success(ACTION_MESSAGE.deleted);
+        }, 100);
       }
 
       if (serverErrors?.message) {

--- a/src/features/device/components/device-actions-button.tsx
+++ b/src/features/device/components/device-actions-button.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { CopyIcon, FolderClosedIcon, MoreHorizontalIcon, Share2Icon, Trash2Icon } from "lucide-react";
+
+import useModal from "@/features/device/hooks/use-modal";
+
+import type { Device, DeviceItem } from "@/features/device/lib/definitions";
+
+import useCopyDeviceId from "@/features/device/hooks/use-copy-device-id";
+
+import { Button } from "@/components/ui/button";
+
+import MoveDeviceModal from "@/features/device/components/move-device-modal";
+
+import ShareDeviceModal from "@/features/device/components/share-device-modal";
+
+import DeleteDeviceModal from "@/features/device/components/delete-device-modal";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+type DeviceActionsButtonProps = {
+  device: Device;
+  types: DeviceItem[] | null;
+  statuses: DeviceItem[] | null;
+  groups: DeviceItem[] | null;
+};
+
+export default function DeviceActionsButton({ device, groups }: DeviceActionsButtonProps) {
+  const { modal, setModal, closeModal } = useModal();
+
+  const { handleCopy } = useCopyDeviceId();
+
+  const deviceId = device.id;
+
+  const deviceName = device.name;
+
+  const groupId = device.groupId;
+
+  return (
+    <>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <DropdownMenuTrigger
+                render={
+                  <Button type="button" variant="outline" size="icon">
+                    <MoreHorizontalIcon />
+                  </Button>
+                }
+              />
+            }
+          />
+          <TooltipContent>
+            <p>Actions</p>
+          </TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent className="w-40">
+          <DropdownMenuItem onClick={() => setModal("move")} className="focus:[&>svg]:stroke-muted-foreground">
+            <FolderClosedIcon className="text-muted-foreground" />
+            Move...
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => handleCopy(deviceId)} className="focus:[&>svg]:stroke-muted-foreground">
+            <CopyIcon className="text-muted-foreground" />
+            Copy ID
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setModal("share")} className="focus:[&>svg]:stroke-muted-foreground">
+            <Share2Icon className="text-muted-foreground" />
+            Share
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onClick={() => setModal("delete")}>
+            <Trash2Icon className="text-danger" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {modal === "move" && (
+        <MoveDeviceModal deviceId={deviceId} groupId={groupId} groups={groups} onClose={closeModal} />
+      )}
+      {modal === "share" && <ShareDeviceModal deviceId={deviceId} onClose={closeModal} />}
+      {modal === "delete" && <DeleteDeviceModal deviceId={deviceId} deviceName={deviceName} onClose={closeModal} />}
+    </>
+  );
+}

--- a/src/features/device/components/device-actions-button.tsx
+++ b/src/features/device/components/device-actions-button.tsx
@@ -1,12 +1,8 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-
 import { CopyIcon, FolderClosedIcon, MoreHorizontalIcon, Share2Icon, Trash2Icon } from "lucide-react";
 
 import useModal from "@/features/device/hooks/use-modal";
-
-import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
 
 import type { Device, DeviceItem } from "@/features/device/lib/definitions";
 
@@ -38,8 +34,6 @@ type DeviceActionsButtonProps = {
 };
 
 export default function DeviceActionsButton({ device, groups }: DeviceActionsButtonProps) {
-  const { replace } = useRouter();
-
   const { modal, setModal, closeModal } = useModal();
 
   const { handleCopy } = useCopyDeviceId();
@@ -49,10 +43,6 @@ export default function DeviceActionsButton({ device, groups }: DeviceActionsBut
   const deviceName = device.name;
 
   const groupId = device.groupId;
-
-  const handleRouteChange = () => {
-    replace(DEVICES_PATH);
-  };
 
   return (
     <>
@@ -98,9 +88,7 @@ export default function DeviceActionsButton({ device, groups }: DeviceActionsBut
         <MoveDeviceModal deviceId={deviceId} groupId={groupId} groups={groups} onClose={closeModal} />
       )}
       {modal === "share" && <ShareDeviceModal deviceId={deviceId} onClose={closeModal} />}
-      {modal === "delete" && (
-        <DeleteDeviceModal deviceId={deviceId} deviceName={deviceName} onClose={handleRouteChange} />
-      )}
+      {modal === "delete" && <DeleteDeviceModal deviceId={deviceId} deviceName={deviceName} onClose={closeModal} />}
     </>
   );
 }

--- a/src/features/device/components/device-actions-button.tsx
+++ b/src/features/device/components/device-actions-button.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+
 import { CopyIcon, FolderClosedIcon, MoreHorizontalIcon, Share2Icon, Trash2Icon } from "lucide-react";
 
 import useModal from "@/features/device/hooks/use-modal";
+
+import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
 
 import type { Device, DeviceItem } from "@/features/device/lib/definitions";
 
@@ -34,6 +38,8 @@ type DeviceActionsButtonProps = {
 };
 
 export default function DeviceActionsButton({ device, groups }: DeviceActionsButtonProps) {
+  const { replace } = useRouter();
+
   const { modal, setModal, closeModal } = useModal();
 
   const { handleCopy } = useCopyDeviceId();
@@ -43,6 +49,10 @@ export default function DeviceActionsButton({ device, groups }: DeviceActionsBut
   const deviceName = device.name;
 
   const groupId = device.groupId;
+
+  const handleRouteChange = () => {
+    replace(DEVICES_PATH);
+  };
 
   return (
     <>
@@ -88,7 +98,9 @@ export default function DeviceActionsButton({ device, groups }: DeviceActionsBut
         <MoveDeviceModal deviceId={deviceId} groupId={groupId} groups={groups} onClose={closeModal} />
       )}
       {modal === "share" && <ShareDeviceModal deviceId={deviceId} onClose={closeModal} />}
-      {modal === "delete" && <DeleteDeviceModal deviceId={deviceId} deviceName={deviceName} onClose={closeModal} />}
+      {modal === "delete" && (
+        <DeleteDeviceModal deviceId={deviceId} deviceName={deviceName} onClose={handleRouteChange} />
+      )}
     </>
   );
 }

--- a/src/features/device/components/device-actions-cell-button.tsx
+++ b/src/features/device/components/device-actions-cell-button.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { toast } from "sonner";
-
-import { useState } from "react";
-
 import {
   CircleEllipsisIcon,
   CopyIcon,
@@ -16,11 +12,11 @@ import {
 
 import type { Device, DeviceGroup, DeviceStatus, DeviceType } from "@/features/device/lib/definitions";
 
-import { ACTION_MESSAGE } from "@/features/device/lib/constants";
-
 import { createDeviceUrlById } from "@/features/device/lib/utils";
 
-import useCopyToClipboard from "@/features/device/hooks/use-copy-to-clipboard";
+import useModal from "@/features/device/hooks/use-modal";
+
+import useCopyDeviceId from "@/features/device/hooks/use-copy-device-id";
 
 import { buttonVariants } from "@/components/ui/button";
 
@@ -49,21 +45,18 @@ type DeviceActionsProps = {
   groups: DeviceGroup[] | null;
 };
 
-export default function DeviceActions({ device, types, statuses, groups }: DeviceActionsProps) {
-  const { copy } = useCopyToClipboard();
+export default function DeviceActionsCellButton({ device, types, statuses, groups }: DeviceActionsProps) {
+  const { handleCopy } = useCopyDeviceId();
 
-  const [modal, setModal] = useState<string | null>(null);
+  const { modal, setModal, closeModal } = useModal();
 
-  const copyDeviceId = async () => {
-    try {
-      await copy(device.id);
-      toast.success(ACTION_MESSAGE.copied);
-    } catch {
-      toast.error("Failed to copy device ID.");
-    }
-  };
+  const deviceId = device.id;
 
-  const viewDeviceInNewTab = () => {
+  const deviceName = device.name;
+
+  const groupId = device.groupId;
+
+  const handleViewDeviceInNewTab = () => {
     const deviceUrl = createDeviceUrlById(device.id);
     window.open(deviceUrl, "_blank");
   };
@@ -87,7 +80,7 @@ export default function DeviceActions({ device, types, statuses, groups }: Devic
           </TooltipContent>
         </Tooltip>
         <DropdownMenuContent className="w-40">
-          <DropdownMenuItem onClick={viewDeviceInNewTab} className="focus:[&>svg]:stroke-muted-foreground">
+          <DropdownMenuItem onClick={handleViewDeviceInNewTab} className="focus:[&>svg]:stroke-muted-foreground">
             <SquareArrowUpRightIcon className="text-muted-foreground" />
             View
           </DropdownMenuItem>
@@ -101,7 +94,7 @@ export default function DeviceActions({ device, types, statuses, groups }: Devic
             Move...
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={copyDeviceId} className="focus:[&>svg]:stroke-muted-foreground">
+          <DropdownMenuItem onClick={() => handleCopy(deviceId)} className="focus:[&>svg]:stroke-muted-foreground">
             <CopyIcon className="text-muted-foreground" />
             Copy ID
           </DropdownMenuItem>
@@ -116,23 +109,14 @@ export default function DeviceActions({ device, types, statuses, groups }: Devic
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-
       {modal === "edit" && (
-        <EditDeviceModal
-          device={device}
-          types={types}
-          statuses={statuses}
-          groups={groups}
-          onClose={() => setModal(null)}
-        />
+        <EditDeviceModal device={device} types={types} statuses={statuses} groups={groups} onClose={closeModal} />
       )}
       {modal === "move" && (
-        <MoveDeviceModal deviceId={device.id} groupId={device.groupId} groups={groups} onClose={() => setModal(null)} />
+        <MoveDeviceModal deviceId={deviceId} groupId={groupId} groups={groups} onClose={closeModal} />
       )}
-      {modal === "share" && <ShareDeviceModal deviceId={device.id} onClose={() => setModal(null)} />}
-      {modal === "delete" && (
-        <DeleteDeviceModal deviceId={device.id} deviceName={device.name} onClose={() => setModal(null)} />
-      )}
+      {modal === "share" && <ShareDeviceModal deviceId={deviceId} onClose={closeModal} />}
+      {modal === "delete" && <DeleteDeviceModal deviceId={deviceId} deviceName={deviceName} onClose={closeModal} />}
     </>
   );
 }

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -14,11 +14,11 @@ import {
   Trash2Icon,
 } from "lucide-react";
 
-import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
-
 import type { Device, DeviceGroup, DeviceStatus, DeviceType } from "@/features/device/lib/definitions";
 
 import { ACTION_MESSAGE } from "@/features/device/lib/constants";
+
+import { createDeviceUrlById } from "@/features/device/lib/utils";
 
 import useCopyToClipboard from "@/features/device/hooks/use-copy-to-clipboard";
 
@@ -64,7 +64,7 @@ export default function DeviceActions({ device, types, statuses, groups }: Devic
   };
 
   const viewDeviceInNewTab = () => {
-    const deviceUrl = `${DEVICES_PATH}/${device.id}`;
+    const deviceUrl = createDeviceUrlById(device.id);
     window.open(deviceUrl, "_blank");
   };
 

--- a/src/features/device/components/device-actions.tsx
+++ b/src/features/device/components/device-actions.tsx
@@ -14,6 +14,8 @@ import {
   Trash2Icon,
 } from "lucide-react";
 
+import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
+
 import type { Device, DeviceGroup, DeviceStatus, DeviceType } from "@/features/device/lib/definitions";
 
 import { ACTION_MESSAGE } from "@/features/device/lib/constants";
@@ -62,8 +64,8 @@ export default function DeviceActions({ device, types, statuses, groups }: Devic
   };
 
   const viewDeviceInNewTab = () => {
-    // Will need to change the URL in the future.
-    window.open("#", "_blank");
+    const deviceUrl = `${DEVICES_PATH}/${device.id}`;
+    window.open(deviceUrl, "_blank");
   };
 
   return (

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -14,9 +14,7 @@ import { cn } from "@/lib/utils";
 
 import type { Options } from "@/lib/definitions";
 
-import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
-
-import { getDeviceTableColumns } from "@/features/device/lib/utils";
+import { createDeviceUrlById, getDeviceTableColumns } from "@/features/device/lib/utils";
 
 import type { SortDirection } from "@/features/device/lib/definitions";
 
@@ -99,7 +97,7 @@ export default async function DeviceTable({
               </NoResultsFoundRow>
             )}
             {data?.map((device) => {
-              const deviceUrl = `${DEVICES_PATH}/${device.id}`;
+              const deviceUrl = createDeviceUrlById(device.id);
 
               return (
                 <TableRow key={device.id} className="[&>td]:px-4">

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -20,6 +20,8 @@ import type { SortDirection } from "@/features/device/lib/definitions";
 
 import { getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
 
+import { ModalProvider } from "@/features/device/providers/modal-provider";
+
 import { Badge } from "@/components/ui/badge";
 
 import { buttonVariants } from "@/components/ui/button";
@@ -83,60 +85,62 @@ export default async function DeviceTable({
   return (
     <div>
       <div className="overflow-hidden border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <DeviceTableColumns columns={columns} />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {(error || !data?.length) && (
-              <NoResultsFoundRow columns={columns.length}>
-                <NoResultsFoundIcon />
-                <NoResultsFoundDescription>No devices to display.</NoResultsFoundDescription>
-              </NoResultsFoundRow>
-            )}
-            {data?.map((device) => {
-              const deviceUrl = createDeviceUrlById(device.id);
+        <ModalProvider>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <DeviceTableColumns columns={columns} />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {(error || !data?.length) && (
+                <NoResultsFoundRow columns={columns.length}>
+                  <NoResultsFoundIcon />
+                  <NoResultsFoundDescription>No devices to display.</NoResultsFoundDescription>
+                </NoResultsFoundRow>
+              )}
+              {data?.map((device) => {
+                const deviceUrl = createDeviceUrlById(device.id);
 
-              return (
-                <TableRow key={device.id} className="[&>td]:px-4">
-                  <TableCell>
-                    <Link
-                      href={deviceUrl}
-                      className={cn(buttonVariants({ variant: "link", size: "sm" }), "px-0 underline")}
-                    >
-                      {device.name}
-                    </Link>
-                  </TableCell>
-                  <TableCell>{device.type}</TableCell>
-                  <TableCell>
-                    <Badge variant="outline">
-                      <span
-                        className={cn(
-                          "size-1.5 rounded-full",
-                          getBadgeIconColorClassesByStatus(device.status.toLowerCase()),
-                        )}
+                return (
+                  <TableRow key={device.id} className="[&>td]:px-4">
+                    <TableCell>
+                      <Link
+                        href={deviceUrl}
+                        className={cn(buttonVariants({ variant: "link", size: "sm" }), "px-0 underline")}
+                      >
+                        {device.name}
+                      </Link>
+                    </TableCell>
+                    <TableCell>{device.type}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline">
+                        <span
+                          className={cn(
+                            "size-1.5 rounded-full",
+                            getBadgeIconColorClassesByStatus(device.status.toLowerCase()),
+                          )}
+                        />
+                        {device.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{device.group}</TableCell>
+                    <TableCell>{device.serialNumber}</TableCell>
+                    <TableCell>{device.ipAddress || "-"}</TableCell>
+                    <TableCell align="right">
+                      <DeviceActionsCellButton
+                        device={device}
+                        types={deviceTypes.data}
+                        statuses={deviceStatuses.data}
+                        groups={deviceGroups.data}
                       />
-                      {device.status}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>{device.group}</TableCell>
-                  <TableCell>{device.serialNumber}</TableCell>
-                  <TableCell>{device.ipAddress || "-"}</TableCell>
-                  <TableCell align="right">
-                    <DeviceActionsCellButton
-                      device={device}
-                      types={deviceTypes.data}
-                      statuses={deviceStatuses.data}
-                      groups={deviceGroups.data}
-                    />
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </ModalProvider>
       </div>
       {data?.length ? (
         <Suspense fallback={<PaginationSkeleton />}>

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -118,7 +118,7 @@ export default async function DeviceTable({
                   </TableCell>
                   <TableCell>{device.group}</TableCell>
                   <TableCell>{device.serialNumber}</TableCell>
-                  <TableCell>{device.ipAddress ?? "-"}</TableCell>
+                  <TableCell>{device.ipAddress || "-"}</TableCell>
                   <TableCell align="right">
                     <DeviceActions
                       device={device}

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -14,6 +14,8 @@ import { cn } from "@/lib/utils";
 
 import type { Options } from "@/lib/definitions";
 
+import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
+
 import { getDeviceTableColumns } from "@/features/device/lib/utils";
 
 import type { SortDirection } from "@/features/device/lib/definitions";
@@ -97,10 +99,15 @@ export default async function DeviceTable({
               </NoResultsFoundRow>
             )}
             {data?.map((device) => {
+              const deviceUrl = `${DEVICES_PATH}/${device.id}`;
+
               return (
                 <TableRow key={device.id} className="[&>td]:px-4">
                   <TableCell>
-                    <Link href="#" className={cn(buttonVariants({ variant: "link", size: "sm" }), "px-0 underline")}>
+                    <Link
+                      href={deviceUrl}
+                      className={cn(buttonVariants({ variant: "link", size: "sm" }), "px-0 underline")}
+                    >
                       {device.name}
                     </Link>
                   </TableCell>

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -26,13 +26,13 @@ import { buttonVariants } from "@/components/ui/button";
 
 import Pagination from "@/features/device/components/pagination";
 
-import DeviceActions from "@/features/device/components/device-actions";
-
 import DeviceTableColumns from "@/features/device/components/device-table-columns";
 
 import PaginationSkeleton from "@/features/device/components/pagination-skeleton";
 
 import { Table, TableBody, TableCell, TableHeader, TableRow } from "@/components/ui/table";
+
+import DeviceActionsCellButton from "@/features/device/components/device-actions-cell-button";
 
 import {
   NoResultsFoundRow,
@@ -125,7 +125,7 @@ export default async function DeviceTable({
                   <TableCell>{device.serialNumber}</TableCell>
                   <TableCell>{device.ipAddress || "-"}</TableCell>
                   <TableCell align="right">
-                    <DeviceActions
+                    <DeviceActionsCellButton
                       device={device}
                       types={deviceTypes.data}
                       statuses={deviceStatuses.data}

--- a/src/features/device/components/edit-device-button.tsx
+++ b/src/features/device/components/edit-device-button.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
-
 import type { Device, DeviceItem } from "@/features/device/lib/definitions";
+
+import useModal from "@/features/device/hooks/use-modal";
 
 import { Button } from "@/components/ui/button";
 
@@ -16,17 +16,15 @@ type EditDeviceButtonProps = {
 };
 
 export default function EditDeviceButton({ device, types, statuses, groups }: EditDeviceButtonProps) {
-  const [modalOpen, setModalOpen] = useState(false);
-
-  const handleCloseModal = () => setModalOpen(false);
+  const { modal, setModal, closeModal } = useModal();
 
   return (
     <>
-      <Button type="button" variant="outline" onClick={() => setModalOpen(true)}>
+      <Button type="button" variant="outline" onClick={() => setModal("edit")}>
         Edit Device
       </Button>
-      {modalOpen && (
-        <EditDeviceModal device={device} types={types} statuses={statuses} groups={groups} onClose={handleCloseModal} />
+      {modal === "edit" && (
+        <EditDeviceModal device={device} types={types} statuses={statuses} groups={groups} onClose={closeModal} />
       )}
     </>
   );

--- a/src/features/device/components/edit-device-button.tsx
+++ b/src/features/device/components/edit-device-button.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+
+import type { Device, DeviceItem } from "@/features/device/lib/definitions";
+
+import { Button } from "@/components/ui/button";
+
+import EditDeviceModal from "@/features/device/components/edit-device-modal";
+
+type EditDeviceButtonProps = {
+  device: Device;
+  types: DeviceItem[] | null;
+  statuses: DeviceItem[] | null;
+  groups: DeviceItem[] | null;
+};
+
+export default function EditDeviceButton({ device, types, statuses, groups }: EditDeviceButtonProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleCloseModal = () => setModalOpen(false);
+
+  return (
+    <>
+      <Button type="button" variant="outline" onClick={() => setModalOpen(true)}>
+        Edit Device
+      </Button>
+      {modalOpen && (
+        <EditDeviceModal device={device} types={types} statuses={statuses} groups={groups} onClose={handleCloseModal} />
+      )}
+    </>
+  );
+}

--- a/src/features/device/components/recent-devices.tsx
+++ b/src/features/device/components/recent-devices.tsx
@@ -20,7 +20,7 @@ import { Badge } from "@/components/ui/badge";
 
 import { buttonVariants } from "@/components/ui/button";
 
-import DeviceActions from "@/features/device/components/device-actions";
+import DeviceActionsCellButton from "@/features/device/components/device-actions-cell-button";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
@@ -102,7 +102,12 @@ export default async function RecentDevices() {
                     <TableCell>{device.group}</TableCell>
                     <TableCell>{device.serialNumber}</TableCell>
                     <TableCell align="right">
-                      <DeviceActions device={device} types={types.data} statuses={statuses.data} groups={groups.data} />
+                      <DeviceActionsCellButton
+                        device={device}
+                        types={types.data}
+                        statuses={statuses.data}
+                        groups={groups.data}
+                      />
                     </TableCell>
                   </TableRow>
                 );

--- a/src/features/device/components/recent-devices.tsx
+++ b/src/features/device/components/recent-devices.tsx
@@ -16,6 +16,8 @@ import { TABLE_COLUMNS } from "@/features/device/lib/constants";
 
 import { createDeviceUrlById, getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
 
+import { ModalProvider } from "@/features/device/providers/modal-provider";
+
 import { Badge } from "@/components/ui/badge";
 
 import { buttonVariants } from "@/components/ui/button";
@@ -42,79 +44,81 @@ export default async function RecentDevices() {
         <Badge variant="secondary">{data?.length ?? 0}</Badge>
       </div>
       <div className="overflow-hidden border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              {TABLE_COLUMNS.map((tableColumn) => {
-                const isActionsColumn = tableColumn.toLowerCase() === "actions";
+        <ModalProvider>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                {TABLE_COLUMNS.map((tableColumn) => {
+                  const isActionsColumn = tableColumn.toLowerCase() === "actions";
 
-                return (
-                  <TableHead key={tableColumn} className={cn("px-4", isActionsColumn ? "text-right" : "")}>
-                    {tableColumn}
-                  </TableHead>
-                );
-              })}
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {error ? (
-              <TableRow>
-                <TableCell colSpan={TABLE_COLUMNS.length}>
-                  <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">
-                    <DatabaseZapIcon className="text-muted size-6" />
-                    <span className="text-muted text-sm">{error}</span>
-                  </div>
-                </TableCell>
+                  return (
+                    <TableHead key={tableColumn} className={cn("px-4", isActionsColumn ? "text-right" : "")}>
+                      {tableColumn}
+                    </TableHead>
+                  );
+                })}
               </TableRow>
-            ) : hasNoData ? (
-              <TableRow>
-                <TableCell colSpan={TABLE_COLUMNS.length}>
-                  <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">
-                    <DatabaseIcon className="text-muted size-6" />
-                    <span className="text-muted text-sm">No devices to display.</span>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ) : (
-              data?.map((device) => {
-                return (
-                  <TableRow key={device.id} className="[&>td]:px-4">
-                    <TableCell>
-                      <Link
-                        href={createDeviceUrlById(device.id)}
-                        className={cn(buttonVariants({ variant: "link", size: "sm" }), "px-0 underline")}
-                      >
-                        {device.name}
-                      </Link>
-                    </TableCell>
-                    <TableCell>{device.type}</TableCell>
-                    <TableCell>
-                      <Badge variant="outline">
-                        <span
-                          className={cn(
-                            "size-1.5 rounded-full",
-                            getBadgeIconColorClassesByStatus(device.status.toLowerCase()),
-                          )}
+            </TableHeader>
+            <TableBody>
+              {error ? (
+                <TableRow>
+                  <TableCell colSpan={TABLE_COLUMNS.length}>
+                    <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">
+                      <DatabaseZapIcon className="text-muted size-6" />
+                      <span className="text-muted text-sm">{error}</span>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ) : hasNoData ? (
+                <TableRow>
+                  <TableCell colSpan={TABLE_COLUMNS.length}>
+                    <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">
+                      <DatabaseIcon className="text-muted size-6" />
+                      <span className="text-muted text-sm">No devices to display.</span>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                data?.map((device) => {
+                  return (
+                    <TableRow key={device.id} className="[&>td]:px-4">
+                      <TableCell>
+                        <Link
+                          href={createDeviceUrlById(device.id)}
+                          className={cn(buttonVariants({ variant: "link", size: "sm" }), "px-0 underline")}
+                        >
+                          {device.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>{device.type}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline">
+                          <span
+                            className={cn(
+                              "size-1.5 rounded-full",
+                              getBadgeIconColorClassesByStatus(device.status.toLowerCase()),
+                            )}
+                          />
+                          {device.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{device.group}</TableCell>
+                      <TableCell>{device.serialNumber}</TableCell>
+                      <TableCell align="right">
+                        <DeviceActionsCellButton
+                          device={device}
+                          types={types.data}
+                          statuses={statuses.data}
+                          groups={groups.data}
                         />
-                        {device.status}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>{device.group}</TableCell>
-                    <TableCell>{device.serialNumber}</TableCell>
-                    <TableCell align="right">
-                      <DeviceActionsCellButton
-                        device={device}
-                        types={types.data}
-                        statuses={statuses.data}
-                        groups={groups.data}
-                      />
-                    </TableCell>
-                  </TableRow>
-                );
-              })
-            )}
-          </TableBody>
-        </Table>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </ModalProvider>
       </div>
     </>
   );

--- a/src/features/device/components/recent-devices.tsx
+++ b/src/features/device/components/recent-devices.tsx
@@ -14,7 +14,7 @@ import { getDeviceStatuses } from "@/dal/status";
 
 import { TABLE_COLUMNS } from "@/features/device/lib/constants";
 
-import { getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
+import { createDeviceUrlById, getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
 
 import { Badge } from "@/components/ui/badge";
 
@@ -80,7 +80,10 @@ export default async function RecentDevices() {
                 return (
                   <TableRow key={device.id} className="[&>td]:px-4">
                     <TableCell>
-                      <Link href="#" className={cn(buttonVariants({ variant: "link", size: "sm" }), "px-0 underline")}>
+                      <Link
+                        href={createDeviceUrlById(device.id)}
+                        className={cn(buttonVariants({ variant: "link", size: "sm" }), "px-0 underline")}
+                      >
                         {device.name}
                       </Link>
                     </TableCell>

--- a/src/features/device/hooks/use-copy-device-id.tsx
+++ b/src/features/device/hooks/use-copy-device-id.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { toast } from "sonner";
+
+import { ACTION_MESSAGE } from "@/features/device/lib/constants";
+
+import useCopyToClipboard from "@/features/device/hooks/use-copy-to-clipboard";
+
+export default function useCopyDeviceId() {
+  const { copy } = useCopyToClipboard();
+
+  const handleCopy = async (deviceId: string) => {
+    try {
+      await copy(deviceId);
+      toast.success(ACTION_MESSAGE.copied);
+    } catch {
+      toast.error("Failed to copy device ID.");
+    }
+  };
+
+  return {
+    handleCopy,
+  };
+}

--- a/src/features/device/hooks/use-modal.tsx
+++ b/src/features/device/hooks/use-modal.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useContext } from "react";
+
+import { ModalContext } from "@/features/device/providers/modal-provider";
+
+export default function useModal() {
+  return useContext(ModalContext);
+}

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -75,7 +75,7 @@ export const updateDevice = async (deviceId: string, _prevState: unknown, formDa
     };
   }
 
-  revalidatePath("/dashboard");
+  revalidatePath(DASHBOARD_PATH);
   revalidatePath(DEVICES_PATH);
 
   return {
@@ -122,7 +122,7 @@ export const moveDevice = async (deviceId: string, _prevState: unknown, formData
     };
   }
 
-  revalidatePath("/dashboard");
+  revalidatePath(DASHBOARD_PATH);
 
   return {
     success: true,
@@ -159,7 +159,7 @@ export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
     };
   }
 
-  revalidatePath("/dashboard");
+  revalidatePath(DASHBOARD_PATH);
 
   return {
     success: true,

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -76,6 +76,7 @@ export const updateDevice = async (deviceId: string, _prevState: unknown, formDa
   }
 
   revalidatePath("/dashboard");
+  revalidatePath(DEVICES_PATH);
 
   return {
     success: true,

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -160,6 +160,7 @@ export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
   }
 
   revalidatePath(DASHBOARD_PATH);
+  revalidatePath(DEVICES_PATH);
 
   return {
     success: true,

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -13,6 +13,8 @@ export type Device = {
 
 type DeviceIdAndName = Pick<Device, "id" | "name">;
 
+export type DeviceItem = { id: string; name: string };
+
 export type DeviceType = DeviceIdAndName;
 
 export type DeviceStatus = DeviceIdAndName;

--- a/src/features/device/lib/utils.ts
+++ b/src/features/device/lib/utils.ts
@@ -1,3 +1,5 @@
+import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
+
 import { DEFAULT_PAGE_SIZE, PAGE_SIZES, TABLE_COLUMNS } from "@/features/device/lib/constants";
 
 export const getBadgeIconColorClassesByStatus = (status: string) => {
@@ -38,3 +40,5 @@ export const validatePageSize = (pageSize: number) => {
 
   return DEFAULT_PAGE_SIZE;
 };
+
+export const createDeviceUrlById = (deviceId: string) => `${DEVICES_PATH}/${deviceId}`;

--- a/src/features/device/providers/modal-provider.tsx
+++ b/src/features/device/providers/modal-provider.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { createContext, useState } from "react";
+
+type ModalType = "edit" | "share" | "move" | "delete";
+
+type ModalContextProps = {
+  modal: ModalType | null;
+  setModal: (modal: ModalType) => void;
+  closeModal: () => void;
+};
+
+export const ModalContext = createContext<ModalContextProps>({ modal: null, setModal: () => {}, closeModal: () => {} });
+
+export function ModalProvider({ children }: { children: React.ReactNode }) {
+  const [modal, setModal] = useState<ModalType | null>(null);
+
+  const handleCloseModal = () => setModal(null);
+
+  const contextValue = {
+    modal,
+    setModal: (modal: ModalType) => setModal(modal),
+    closeModal: handleCloseModal,
+  };
+
+  return <ModalContext.Provider value={contextValue}>{children}</ModalContext.Provider>;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,3 +9,9 @@ export const TOOLTIP_OFFSET = 12;
 export const MAX_ROWS = 10;
 
 export const CHART_CONTAINER_HEIGHT = 256;
+
+export const HOME_PATH = "/";
+
+export const NOT_FOUND_TITLE = "Resource Not Found";
+
+export const NOT_FOUND_DESCRIPTION = "The resource you are looking for was not found.";


### PR DESCRIPTION
This PR introduces the device page. It also introduces the not found page for resources that do not exist.

## Changes
- Built the device details page.
- Built the loading UI for pending promises.
- Added metadata to the device page.
- Built the not found page. Users will be taken to the home page if the CTA is clicked.
- Refactored the `deleteDevice` action to make sure that the devices path is revalidated after a device deletion.
- Replaced the URL links of the devices via the table cells.
- Replaced the device URL via the dropdown menu.
- Created a hook to manage modal state. A modal provider was created as well.
- Created a utility function that generates the device URL link by device ID.
- Added a fallback for devices that do not have an IP address.
- Moved logic to copy the device ID into the hook `useCopyDeviceId`.
- Added a 100ms delay to the toast notification that shows after a device has been deleted.
- Added logic to the form action via the delete device modal to redirect users to the devices page if the operation was successful.
- Renamed `DeviceActions` to `DeviceActionsCellButton`.