### PR TITLE
Protect all profile subroutes

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -24,5 +24,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/devices/:path*", "/profile", "/login"],
+  matcher: ["/dashboard/:path*", "/devices/:path*", "/profile/:path*", "/login"],
 };


### PR DESCRIPTION
This PR updates the matcher config via `proxy.ts`. It ensures that unauthorized users accessing sub routes from the resource `/profile` are redirected to the login page. Authenticated users will continue to see the not found page if they access a resource that does not exist via the route `/profile`.