### PR TITLE
Refactor TABLE_COLUMNS constant

### DIFF
--- a/src/app/api/devices/export/route.ts
+++ b/src/app/api/devices/export/route.ts
@@ -6,23 +6,11 @@ import { getSession } from "@/dal/session";
 
 import { MAX_ROWS } from "@/lib/constants";
 
-import { createFileName } from "@/features/device/lib/utils";
-
 import type { Device } from "@/features/device/lib/definitions";
 
 import { DEFAULT_PAGE_SIZE } from "@/features/device/lib/constants";
 
-const TABLE_COLUMNS = [
-  { id: "id", header: "ID" },
-  { id: "name", header: "Name" },
-  { id: "type", header: "Type" },
-  { id: "status", header: "Status" },
-  { id: "group", header: "Group" },
-  { id: "serialNumber", header: "Serial Number" },
-  { id: "ipAddress", header: "IP Address" },
-  { id: "createdAt", header: "Created At" },
-  { id: "updatedAt", header: "Updated At" },
-];
+import { createFileName, getTableColumns } from "@/features/device/lib/utils";
 
 const generateDeviceRow = (device: Device) => {
   const { id, name, type, status, group, serialNumber, ipAddress } = device;
@@ -32,7 +20,9 @@ const generateDeviceRow = (device: Device) => {
 export const GET = async () => {
   await getSession();
 
-  const headers = TABLE_COLUMNS.map((tableColumn) => tableColumn.header);
+  const tableColumns = getTableColumns("id", "name", "type", "status", "group", "serialNumber", "ipAddress");
+
+  const headers = tableColumns.map((tableColumn) => tableColumn.header);
 
   const header = `${headers.join(",")}\n`;
 

--- a/src/features/device/components/device-table-columns.tsx
+++ b/src/features/device/components/device-table-columns.tsx
@@ -4,32 +4,28 @@ import { cn } from "@/lib/utils";
 
 import { ChevronUpIcon } from "lucide-react";
 
-import { getDeviceTableColumns } from "@/features/device/lib/utils";
-
-import type { SortDirection } from "@/features/device/lib/definitions";
+import type { SortDirection, TableColumnItem } from "@/features/device/lib/definitions";
 
 import useSort from "@/features/device/hooks/use-sort";
 
 import { TableHead } from "@/components/ui/table";
 
-type DeviceTableColumnsProps = ReturnType<typeof getDeviceTableColumns>;
-
-export default function DeviceTableColumns({ columns }: { columns: DeviceTableColumnsProps }) {
+export default function DeviceTableColumns({ columns }: { columns: TableColumnItem[] }) {
   const { sort, handleSort } = useSort();
 
   return columns.map((tableColumn) => {
-    const isActionsColumn = tableColumn.toLowerCase() === "actions";
+    const isActionsColumn = tableColumn.id === "actions";
 
-    const isSortedColumn = tableColumn.toLowerCase() === sort?.name;
+    const isSortedColumn = tableColumn.header.toLowerCase() === sort?.name;
 
     return (
       <TableHead
-        key={tableColumn}
+        key={tableColumn.id}
         className={cn("px-4", isActionsColumn ? "text-right" : "hover:bg-accent cursor-pointer")}
         onClick={!isActionsColumn ? (e) => handleSort(e.currentTarget.innerText) : undefined}
       >
         <div className="flex items-center gap-1">
-          <span className={isActionsColumn ? "sr-only" : undefined}>{tableColumn}</span>
+          <span className={isActionsColumn ? "sr-only" : undefined}>{tableColumn.header}</span>
           {!isActionsColumn && isSortedColumn && <SortIcon direction={sort.direction} />}
         </div>
       </TableHead>

--- a/src/features/device/components/device-table-skeleton.tsx
+++ b/src/features/device/components/device-table-skeleton.tsx
@@ -1,13 +1,14 @@
 import { cn } from "@/lib/utils";
 
-import { getDeviceTableColumns } from "@/features/device/lib/utils";
+import { getTableColumns } from "@/features/device/lib/utils";
 
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export default function DeviceTableSkeleton() {
-  const columns = getDeviceTableColumns();
+  const tableColumns = getTableColumns("name", "type", "status", "group", "serialNumber", "ipAddress", "actions");
+
   const rows = new Array(8).fill(null);
 
   return (
@@ -15,12 +16,12 @@ export default function DeviceTableSkeleton() {
       <Table>
         <TableHeader>
           <TableRow>
-            {columns.map((column) => {
-              const isActionsColumn = column.toLowerCase() === "actions";
+            {tableColumns.map((tableColumn) => {
+              const isActionsColumn = tableColumn.id === "actions";
 
               return (
-                <TableHead key={column} className={cn("px-4", isActionsColumn ? "text-right" : "")}>
-                  <span className={isActionsColumn ? "sr-only" : ""}>{column}</span>
+                <TableHead key={tableColumn.id} className={cn("px-4", isActionsColumn ? "text-right" : "")}>
+                  <span className={isActionsColumn ? "sr-only" : ""}>{tableColumn.header}</span>
                 </TableHead>
               );
             })}
@@ -30,9 +31,9 @@ export default function DeviceTableSkeleton() {
           {rows.map((_, idx) => {
             return (
               <TableRow key={`device-table-skeleton-row-${idx}`} className="[&>td]:px-4">
-                {columns.map((_, idx) => (
+                {tableColumns.map((_, idx) => (
                   <TableCell key={`device-table-skeleton-cell-${idx}`} className="h-10" align="right">
-                    <Skeleton className={cn("h-3 w-full", `${idx === columns.length - 1 ? "w-6" : ""}`)} />
+                    <Skeleton className={cn("h-3 w-full", `${idx === tableColumns.length - 1 ? "w-6" : ""}`)} />
                   </TableCell>
                 ))}
               </TableRow>

--- a/src/features/device/components/device-table.tsx
+++ b/src/features/device/components/device-table.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils";
 
 import type { Options } from "@/lib/definitions";
 
-import { createDeviceUrlById, getDeviceTableColumns } from "@/features/device/lib/utils";
+import { createDeviceUrlById, getTableColumns } from "@/features/device/lib/utils";
 
 import type { SortDirection } from "@/features/device/lib/definitions";
 
@@ -76,7 +76,7 @@ export default async function DeviceTable({
 
   const { data, error } = devices;
 
-  const columns = getDeviceTableColumns();
+  const tableColumns = getTableColumns("name", "type", "status", "group", "serialNumber", "ipAddress", "actions");
 
   const totalPagesPromise = getDevicesPages({ pagination: options.pagination, filters: options.filters });
 
@@ -86,12 +86,12 @@ export default async function DeviceTable({
         <Table>
           <TableHeader>
             <TableRow>
-              <DeviceTableColumns columns={columns} />
+              <DeviceTableColumns columns={tableColumns} />
             </TableRow>
           </TableHeader>
           <TableBody>
             {(error || !data?.length) && (
-              <NoResultsFoundRow columns={columns.length}>
+              <NoResultsFoundRow columns={tableColumns.length}>
                 <NoResultsFoundIcon />
                 <NoResultsFoundDescription>No devices to display.</NoResultsFoundDescription>
               </NoResultsFoundRow>

--- a/src/features/device/components/recent-devices.tsx
+++ b/src/features/device/components/recent-devices.tsx
@@ -12,9 +12,7 @@ import { getDeviceGroups } from "@/dal/group";
 
 import { getDeviceStatuses } from "@/dal/status";
 
-import { TABLE_COLUMNS } from "@/features/device/lib/constants";
-
-import { createDeviceUrlById, getBadgeIconColorClassesByStatus } from "@/features/device/lib/utils";
+import { createDeviceUrlById, getBadgeIconColorClassesByStatus, getTableColumns } from "@/features/device/lib/utils";
 
 import { Badge } from "@/components/ui/badge";
 
@@ -35,6 +33,8 @@ export default async function RecentDevices() {
 
   const hasNoData = !data?.length && data?.length === 0;
 
+  const tableColumns = getTableColumns("name", "type", "status", "group", "serialNumber", "actions");
+
   return (
     <>
       <div className="mb-5 flex items-center gap-2">
@@ -45,12 +45,12 @@ export default async function RecentDevices() {
         <Table>
           <TableHeader>
             <TableRow>
-              {TABLE_COLUMNS.map((tableColumn) => {
-                const isActionsColumn = tableColumn.toLowerCase() === "actions";
+              {tableColumns.map((tableColumn) => {
+                const isActionsColumn = tableColumn.id === "actions";
 
                 return (
-                  <TableHead key={tableColumn} className={cn("px-4", isActionsColumn ? "text-right" : "")}>
-                    {tableColumn}
+                  <TableHead key={tableColumn.id} className={cn("px-4", isActionsColumn ? "text-right" : "")}>
+                    {isActionsColumn ? "" : tableColumn.header}
                   </TableHead>
                 );
               })}
@@ -59,7 +59,7 @@ export default async function RecentDevices() {
           <TableBody>
             {error ? (
               <TableRow>
-                <TableCell colSpan={TABLE_COLUMNS.length}>
+                <TableCell colSpan={tableColumns.length}>
                   <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">
                     <DatabaseZapIcon className="text-muted size-6" />
                     <span className="text-muted text-sm">{error}</span>
@@ -68,7 +68,7 @@ export default async function RecentDevices() {
               </TableRow>
             ) : hasNoData ? (
               <TableRow>
-                <TableCell colSpan={TABLE_COLUMNS.length}>
+                <TableCell colSpan={tableColumns.length}>
                   <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">
                     <DatabaseIcon className="text-muted size-6" />
                     <span className="text-muted text-sm">No devices to display.</span>

--- a/src/features/device/lib/constants.ts
+++ b/src/features/device/lib/constants.ts
@@ -1,4 +1,17 @@
-export const TABLE_COLUMNS = ["Name", "Type", "Status", "Group", "Serial Number", ""];
+import type { TableColumnItem } from "@/features/device/lib/definitions";
+
+export const TABLE_COLUMNS: TableColumnItem[] = [
+  { id: "id", header: "ID" },
+  { id: "name", header: "Name" },
+  { id: "type", header: "Type" },
+  { id: "status", header: "Status" },
+  { id: "group", header: "Group" },
+  { id: "serialNumber", header: "Serial Number" },
+  { id: "ipAddress", header: "IP Address" },
+  { id: "createdAt", header: "Created At" },
+  { id: "updatedAt", header: "Updated At" },
+  { id: "actions", header: "Actions" },
+];
 
 export const FORM_ID = "device-form";
 

--- a/src/features/device/lib/definitions.ts
+++ b/src/features/device/lib/definitions.ts
@@ -32,3 +32,20 @@ export type SelectFieldItem = {
   label: string;
   value: string;
 };
+
+export type TableColumn =
+  | "id"
+  | "name"
+  | "type"
+  | "status"
+  | "group"
+  | "serialNumber"
+  | "ipAddress"
+  | "createdAt"
+  | "updatedAt"
+  | "actions";
+
+export type TableColumnItem = {
+  id: TableColumn;
+  header: string;
+};

--- a/src/features/device/lib/utils.ts
+++ b/src/features/device/lib/utils.ts
@@ -1,5 +1,7 @@
 import { DEVICES_PATH } from "@/features/dashboard/lib/constants";
 
+import type { TableColumn } from "@/features/device/lib/definitions";
+
 import { DEFAULT_PAGE_SIZE, PAGE_SIZES, TABLE_COLUMNS } from "@/features/device/lib/constants";
 
 export const getBadgeIconColorClassesByStatus = (status: string) => {
@@ -16,11 +18,6 @@ export const getBadgeIconColorClassesByStatus = (status: string) => {
 };
 
 export const generateId = (value: string, separator: string = "-") => value.toLowerCase().split(" ").join(separator);
-
-export const getDeviceTableColumns = () => {
-  const newColumns = TABLE_COLUMNS.slice(0, TABLE_COLUMNS.length - 1);
-  return [...newColumns, "IP Address", "Actions"] as const;
-};
 
 export const getFilteredSearchParams = (searchParams: string[], values: string[]) => {
   const validatedSearchParams: string[] = [];
@@ -44,3 +41,14 @@ export const validatePageSize = (pageSize: number) => {
 export const createDeviceUrlById = (deviceId: string) => `${DEVICES_PATH}/${deviceId}`;
 
 export const createFileName = () => `devices-export-${new Date().toISOString()}`;
+
+export const getTableColumns = (...columns: TableColumn[]) => {
+  const selectedColumns = [];
+
+  for (const column of columns) {
+    const selectedColumn = TABLE_COLUMNS.filter((tableColumn) => tableColumn.id === column);
+    selectedColumns.push(selectedColumn[0]);
+  }
+
+  return selectedColumns;
+};


### PR DESCRIPTION
This PR refactors the table columns constant.

## Changes
- Refactored `TABLE_COLUMNS` constant.
- Created type `TableColumn`.
- Created type `TableColumnItem`.
- Created the utility function `getTableColumns`. This function returns table column items based on the parameters.
- Deleted the utility function `getDeviceTableColumns`.
- Updated the devices tables using the new table columns constant.