### PR TITLE
Use the PostgreSQL NULLIF function to replace empty IP address string values with NULL

### DIFF
--- a/src/features/device/lib/helpers.ts
+++ b/src/features/device/lib/helpers.ts
@@ -36,7 +36,7 @@ export const getSqlOrderByStatementBySort = (sort: Options["sort"]) => {
 
   const tableColumn = getTableColumn(columnName);
 
-  return sql`${isIpAddress ? sql`${tableColumn}::inet` : tableColumn} ${sortDirection === "asc" ? sql`ASC` : sql`DESC`}`;
+  return sql`${isIpAddress ? sql`NULLIF(${tableColumn}, '')::inet` : tableColumn} ${sortDirection === "asc" ? sql`ASC` : sql`DESC`}`;
 };
 
 export const getSqlWhereStatementByFilters = (filters: Options["filters"]) => {


### PR DESCRIPTION
This PR fixes a bug where the IP Address table column was not sorting the rows.

## Changes
- Added the PostgreSQL utility function `NULLIF` to replace empty columns that do not have an IP address. The function will replace the empty string value with `NULL`. This will prevent the invalid input syntax error when using the `::inet` type cast.