### PR TITLE
Feature/button group border and download link

### DIFF
--- a/src/features/device/components/button-actions.tsx
+++ b/src/features/device/components/button-actions.tsx
@@ -25,7 +25,7 @@ export default function ButtonActions() {
             render={
               <DropdownMenuTrigger
                 aria-label="More Options"
-                className={buttonVariants({ variant: "outline", size: "icon" })}
+                className={buttonVariants({ variant: "outline", size: "icon", className: "border-l-0" })}
               >
                 <MoreHorizontalIcon />
               </DropdownMenuTrigger>
@@ -52,7 +52,7 @@ export default function ButtonActions() {
 
 function NewDeviceLink() {
   return (
-    <Link href={NEW_DEVICE_PATH} className={buttonVariants()}>
+    <Link href={NEW_DEVICE_PATH} className={buttonVariants({ variant: "outline" })}>
       <PlusIcon />
       New Device
     </Link>

--- a/src/features/device/components/button-actions.tsx
+++ b/src/features/device/components/button-actions.tsx
@@ -1,6 +1,12 @@
+"use client";
+
 import Link from "next/link";
 
+import { useRouter } from "next/navigation";
+
 import { DownloadCloudIcon, ImportIcon, MoreHorizontalIcon, PlusIcon } from "lucide-react";
+
+import { DOWNLOAD_CSV_URL } from "@/features/device/lib/constants";
 
 import { NEW_DEVICE_PATH } from "@/features/dashboard/lib/constants";
 
@@ -16,6 +22,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 export default function ButtonActions() {
+  const { push } = useRouter();
+
+  const handleDownload = () => {
+    push(DOWNLOAD_CSV_URL);
+  };
+
   return (
     <>
       <NewDeviceLink />
@@ -36,7 +48,7 @@ export default function ButtonActions() {
           </TooltipContent>
         </Tooltip>
         <DropdownMenuContent align="end" className="w-40">
-          <DropdownMenuItem>
+          <DropdownMenuItem onClick={handleDownload}>
             <DownloadCloudIcon />
             Download CSV
           </DropdownMenuItem>

--- a/src/features/device/components/button-actions.tsx
+++ b/src/features/device/components/button-actions.tsx
@@ -17,7 +17,7 @@ import {
 
 export default function ButtonActions() {
   return (
-    <div className="flex items-center gap-1">
+    <>
       <NewDeviceLink />
       <DropdownMenu>
         <Tooltip>
@@ -46,7 +46,7 @@ export default function ButtonActions() {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
This PR refactors the button group via the devices page.

## Changes
- Set the add device link's variant to `outline`.
- Removed the flex gap between the link and the actions button.
- Removed the left border from the actions button.
- Created a function that downloads device data in CSV format.
- Added the `use client` directive to the button actions component.