### PR TITLE
Remove getSession from try/catch block and return null if user or account does not exist

### DIFF
--- a/src/dal/account.ts
+++ b/src/dal/account.ts
@@ -9,26 +9,23 @@ import { getSession } from "./session";
 import { accountsTable } from "@/db/schemas";
 
 const getAccount = async () => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db.select().from(accountsTable).where(eq(accountsTable.userId, session.userId));
     const account = data[0];
 
     return account;
-  } catch (error) {
-    console.error(error);
-    throw new Error("Failed to get account.");
+  } catch {
+    console.error("Failed to get account.");
+    return null;
   }
 };
 
 export const getAccountUpdatedDate = async () => {
-  try {
-    const data = await getAccount();
+  const data = await getAccount();
 
-    return data.updatedAt;
-  } catch (error) {
-    console.error(error);
-    throw new Error("Failed to get account updated date.");
-  }
+  if (!data) return null;
+
+  return data.updatedAt;
 };

--- a/src/dal/user.ts
+++ b/src/dal/user.ts
@@ -9,29 +9,26 @@ import { usersTable } from "@/db/schemas";
 import { getSession } from "@/dal/session";
 
 export const getUser = async () => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db.select().from(usersTable).where(eq(usersTable.id, session.userId));
     const user = data[0];
 
     return user;
-  } catch (error) {
-    console.error(error);
-    throw new Error("Failed to get user.");
+  } catch {
+    console.error("Failed to get user.");
+    return null;
   }
 };
 
 export const getUserNameAndEmail = async () => {
-  try {
-    const user = await getUser();
+  const user = await getUser();
 
-    return {
-      name: user.name,
-      email: user.email,
-    };
-  } catch (error) {
-    console.error(error);
-    throw new Error("Failed to get the user's name and email address.");
-  }
+  if (!user) return null;
+
+  return {
+    name: user.name,
+    email: user.email,
+  };
 };

--- a/src/features/dashboard/components/user-profile.tsx
+++ b/src/features/dashboard/components/user-profile.tsx
@@ -9,10 +9,12 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 export default async function UserProfile() {
   const user = await getUserNameAndEmail();
 
+  if (!user) return null;
+
   return (
     <div className="my-4 flex items-center gap-2 px-3">
       <Avatar>
-        <AvatarImage alt={user.name} src="/avatar.png" />
+        <AvatarImage alt={user?.name} src="/avatar.png" />
         <AvatarFallback delay={AVATAR_FALLBACK_DELAY}>{getUserInitials(user.name)}</AvatarFallback>
       </Avatar>
       <div className="flex flex-col text-left">

--- a/src/features/profile/components/personal-card.tsx
+++ b/src/features/profile/components/personal-card.tsx
@@ -11,6 +11,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 export default async function PersonalCard() {
   const user = await getUserNameAndEmail();
 
+  if (!user) return null;
+
   return (
     <Card>
       <CardHeader>

--- a/src/features/profile/components/security-card.tsx
+++ b/src/features/profile/components/security-card.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 export default async function SecurityCard() {
   const passwordLastChangedDate = await getAccountUpdatedDate();
 
-  const passwordLastChanged = formatRelativeTime(passwordLastChangedDate);
+  const passwordLastChanged = passwordLastChangedDate ? formatRelativeTime(passwordLastChangedDate) : null;
 
   return (
     <Card>
@@ -22,7 +22,8 @@ export default async function SecurityCard() {
           <div>
             <h3 className="font-medium">Password</h3>
             <p className="text-muted-foreground">
-              Last changed <strong className="font-medium">{passwordLastChanged}</strong>.
+              Last changed&nbsp;
+              <strong className="font-medium">{passwordLastChanged ? passwordLastChanged : "unavailable"}</strong>.
             </p>
           </div>
           <Button type="button" variant="outline" disabled>

--- a/src/features/profile/components/user-card.tsx
+++ b/src/features/profile/components/user-card.tsx
@@ -11,7 +11,11 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 export default async function UserCard() {
-  const { name, createdAt } = await getUser();
+  const user = await getUser();
+
+  if (!user) return null;
+
+  const { name, createdAt } = user;
 
   return (
     <Card>

--- a/src/features/profile/lib/actions.ts
+++ b/src/features/profile/lib/actions.ts
@@ -10,6 +10,8 @@ export const deleteAccount = async () => {
   try {
     const currentUser = await getUser();
 
+    if (!currentUser) throw new Error();
+
     if (!canDeleteAccount(currentUser)) {
       return {
         error: ACTION_MESSAGE.denied,
@@ -27,6 +29,8 @@ export const deleteAccount = async () => {
 export const updateName = async () => {
   try {
     const currentUser = await getUser();
+
+    if (!currentUser) throw new Error();
 
     if (!canDeleteAccount(currentUser)) {
       return {


### PR DESCRIPTION
This PR addresses build errors where some routes weren't able to be rendered statically because of the use of `headers` via the data access layer.

## Changes
- Moved the `getSession` function outside of the `try/catch` block via the `getUser` function.
- Moved the `getSession` function outside of the `try/catch` block via the `getAccount` function.
- Returned `null` if the user was not found via the database. Components that require the user's data will return `null`.
- Returned `null` if the user's account was not found via the database.
- Threw errors via the delete account and update name actions if `currentUser` is `null`.