### PR TITLE
Refactor/try catch blocks

### DIFF
--- a/src/dal/device.ts
+++ b/src/dal/device.ts
@@ -17,9 +17,9 @@ import { getSqlOrderByStatementBySort, getSqlWhereStatementByFilters } from "@/f
 import { deviceGroupsTable, devicesTable, deviceStatusesTable, deviceTypesTable, usersTable } from "@/db/schemas";
 
 export const getDevicesCount = async (): Promise<ActionResult<number>> => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db.select({ count: count() }).from(devicesTable).where(eq(devicesTable.userId, session.userId));
 
     return {
@@ -35,9 +35,9 @@ export const getDevicesCount = async (): Promise<ActionResult<number>> => {
 };
 
 export const getDevicesCountByStatus = async (status: string): Promise<ActionResult<number>> => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db
       .select({ count: count() })
       .from(devicesTable)
@@ -58,9 +58,9 @@ export const getDevicesCountByStatus = async (status: string): Promise<ActionRes
 };
 
 export const getDevices = async (options: Options): Promise<ActionResult<Device[]>> => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db
       .select({
         id: devicesTable.id,
@@ -98,9 +98,9 @@ export const getDevices = async (options: Options): Promise<ActionResult<Device[
 export const getDevicesPages = async (options: Pick<Options, "pagination" | "filters">) => {
   const { pagination, filters } = options;
 
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db
       .select({ count: count() })
       .from(devicesTable)
@@ -124,9 +124,9 @@ export const getDevicesPages = async (options: Pick<Options, "pagination" | "fil
 };
 
 export const getDeviceById = async (deviceId: string) => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db
       .select({
         id: devicesTable.id,

--- a/src/dal/group.ts
+++ b/src/dal/group.ts
@@ -11,9 +11,9 @@ import type { ActionResult } from "@/lib/definitions";
 import { deviceGroupsTable, devicesTable, usersTable } from "@/db/schemas";
 
 export const getDeviceGroups = async (): Promise<ActionResult<Array<{ id: string; name: string }>>> => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db
       .select({
         id: deviceGroupsTable.id,
@@ -36,9 +36,9 @@ export const getDeviceGroups = async (): Promise<ActionResult<Array<{ id: string
 };
 
 export const getDeviceCountsByGroup = async (): Promise<ActionResult<{ name: string; devices: number }[]>> => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db
       .select({
         name: deviceGroupsTable.name,

--- a/src/dal/status.ts
+++ b/src/dal/status.ts
@@ -11,9 +11,9 @@ import type { ActionResult } from "@/lib/definitions";
 import { deviceStatusesTable, usersTable } from "@/db/schemas";
 
 export const getDeviceStatuses = async (): Promise<ActionResult<Array<{ id: string; name: string }>>> => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db
       .select({
         id: deviceStatusesTable.id,

--- a/src/dal/type.ts
+++ b/src/dal/type.ts
@@ -11,9 +11,9 @@ import type { ActionResult } from "@/lib/definitions";
 import { devicesTable, deviceTypesTable, usersTable } from "@/db/schemas";
 
 export const getDeviceTypes = async (): Promise<ActionResult<Array<{ id: string; name: string }>>> => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db
       .select({
         id: deviceTypesTable.id,
@@ -36,9 +36,9 @@ export const getDeviceTypes = async (): Promise<ActionResult<Array<{ id: string;
 };
 
 export const getDeviceCountsByType = async (): Promise<ActionResult<Array<{ name: string; total: number }>>> => {
-  try {
-    const session = await getSession();
+  const session = await getSession();
 
+  try {
     const data = await db
       .select({
         name: deviceTypesTable.name,

--- a/src/features/auth/lib/actions.ts
+++ b/src/features/auth/lib/actions.ts
@@ -20,19 +20,19 @@ export const authenticateUser = async (_prevState: unknown, formData: FormData):
     password: formData.get("password"),
   });
 
+  if (!parsedFields.success) {
+    const { fieldErrors } = z.flattenError(parsedFields.error);
+
+    return {
+      success: false,
+      serverErrors: {
+        email: fieldErrors.email?.toString(),
+        password: fieldErrors.password?.toString(),
+      },
+    };
+  }
+
   try {
-    if (!parsedFields.success) {
-      const { fieldErrors } = z.flattenError(parsedFields.error);
-
-      return {
-        success: false,
-        serverErrors: {
-          email: fieldErrors.email?.toString(),
-          password: fieldErrors.password?.toString(),
-        },
-      };
-    }
-
     const response = await auth.api.signInEmail({
       body: {
         email: parsedFields.data.email,

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -36,23 +36,23 @@ export const updateDevice = async (deviceId: string, _prevState: unknown, formDa
     serialNumber: formData.get("serial-number"),
   });
 
+  if (!parsedFields.success) {
+    const { fieldErrors } = z.flattenError(parsedFields.error);
+
+    return {
+      success: false,
+      serverErrors: {
+        name: fieldErrors.name?.toString(),
+        type: fieldErrors.typeId?.toString(),
+        status: fieldErrors.statusId?.toString(),
+        group: fieldErrors.groupId?.toString(),
+        ipAddress: fieldErrors.ipAddress?.toString(),
+        serialNumber: fieldErrors.serialNumber?.toString(),
+      },
+    };
+  }
+
   try {
-    if (!parsedFields.success) {
-      const { fieldErrors } = z.flattenError(parsedFields.error);
-
-      return {
-        success: false,
-        serverErrors: {
-          name: fieldErrors.name?.toString(),
-          type: fieldErrors.typeId?.toString(),
-          status: fieldErrors.statusId?.toString(),
-          group: fieldErrors.groupId?.toString(),
-          ipAddress: fieldErrors.ipAddress?.toString(),
-          serialNumber: fieldErrors.serialNumber?.toString(),
-        },
-      };
-    }
-
     await db.transaction(async (tx) => {
       await tx
         .update(devicesTable)
@@ -89,22 +89,22 @@ type MoveDeviceAction = ActionReturnType<Partial<{ group: string }>>;
 export const moveDevice = async (deviceId: string, _prevState: unknown, formData: FormData): MoveDeviceAction => {
   const { userId } = await getSession();
 
+  const parsedFields = MoveDeviceSchema.safeParse({
+    groupId: formData.get("group"),
+  });
+
+  if (!parsedFields.success) {
+    const { fieldErrors } = z.flattenError(parsedFields.error);
+
+    return {
+      success: false,
+      serverErrors: {
+        group: fieldErrors.groupId?.toString(),
+      },
+    };
+  }
+
   try {
-    const parsedFields = MoveDeviceSchema.safeParse({
-      groupId: formData.get("group"),
-    });
-
-    if (!parsedFields.success) {
-      const { fieldErrors } = z.flattenError(parsedFields.error);
-
-      return {
-        success: false,
-        serverErrors: {
-          group: fieldErrors.groupId?.toString(),
-        },
-      };
-    }
-
     await db.transaction(async (tx) => {
       await tx
         .update(devicesTable)
@@ -135,18 +135,18 @@ type DeleteDeviceAction = ActionReturnType<{ message: string }>;
 export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
   const { userId } = await getSession();
 
+  const parsedDeviceId = DeleteDeviceSchema.safeParse(deviceId);
+
+  if (!parsedDeviceId.success) {
+    return {
+      success: false,
+      serverErrors: {
+        message: "Failed to delete device.",
+      },
+    };
+  }
+
   try {
-    const parsedDeviceId = DeleteDeviceSchema.safeParse(deviceId);
-
-    if (!parsedDeviceId.success) {
-      return {
-        success: false,
-        serverErrors: {
-          message: "Failed to delete device.",
-        },
-      };
-    }
-
     await db.transaction(async (tx) => {
       await tx.delete(devicesTable).where(and(eq(devicesTable.id, deviceId), eq(devicesTable.userId, userId)));
     });
@@ -180,23 +180,23 @@ export const createDevice = async (_prevState: unknown, formData: FormData) => {
     ipAddress: formData.get("ip-address")?.toString().trim(),
   });
 
+  if (!parsedFields.success) {
+    const { fieldErrors } = z.flattenError(parsedFields.error);
+
+    return {
+      success: false,
+      serverErrors: {
+        name: fieldErrors.name?.toString(),
+        typeId: fieldErrors.typeId?.toString(),
+        statusId: fieldErrors.statusId?.toString(),
+        groupId: fieldErrors.groupId?.toString(),
+        serialNumber: fieldErrors.serialNumber?.toString(),
+        ipAddress: fieldErrors.ipAddress?.toString(),
+      },
+    };
+  }
+
   try {
-    if (!parsedFields.success) {
-      const { fieldErrors } = z.flattenError(parsedFields.error);
-
-      return {
-        success: false,
-        serverErrors: {
-          name: fieldErrors.name?.toString(),
-          typeId: fieldErrors.typeId?.toString(),
-          statusId: fieldErrors.statusId?.toString(),
-          groupId: fieldErrors.groupId?.toString(),
-          serialNumber: fieldErrors.serialNumber?.toString(),
-          ipAddress: fieldErrors.ipAddress?.toString(),
-        },
-      };
-    }
-
     await db.transaction(async (tx) => {
       await tx.insert(devicesTable).values({
         id: generateId(),

--- a/src/features/device/lib/actions.ts
+++ b/src/features/device/lib/actions.ts
@@ -87,9 +87,9 @@ export const updateDevice = async (deviceId: string, _prevState: unknown, formDa
 type MoveDeviceAction = ActionReturnType<Partial<{ group: string }>>;
 
 export const moveDevice = async (deviceId: string, _prevState: unknown, formData: FormData): MoveDeviceAction => {
-  try {
-    const { userId } = await getSession();
+  const { userId } = await getSession();
 
+  try {
     const parsedFields = MoveDeviceSchema.safeParse({
       groupId: formData.get("group"),
     });
@@ -133,9 +133,9 @@ export const moveDevice = async (deviceId: string, _prevState: unknown, formData
 type DeleteDeviceAction = ActionReturnType<{ message: string }>;
 
 export const deleteDevice = async (deviceId: string): DeleteDeviceAction => {
-  try {
-    const { userId } = await getSession();
+  const { userId } = await getSession();
 
+  try {
     const parsedDeviceId = DeleteDeviceSchema.safeParse(deviceId);
 
     if (!parsedDeviceId.success) {


### PR DESCRIPTION
This PR updates the try catch block code. It moves `getSession` functions and synchronous code outside of try catch blocks.

## Changes
- Moved `getSession` functions outside of `try/catch` blocks.
- Moved synchronous code such as checking parsed fields outside of `try/catch` blocks.