### PR TITLE
Refactor/device button groups

### DIFF
--- a/src/app/(dashboard)/devices/page.tsx
+++ b/src/app/(dashboard)/devices/page.tsx
@@ -18,7 +18,7 @@ import SearchProvider from "@/features/device/providers/search-provider";
 
 import DeviceTable from "@/features/device/components/device-table";
 
-import ButtonActions from "@/features/device/components/button-actions";
+import DeviceButtonActions from "@/features/device/components/device-button-actions";
 
 import FilterPopover from "@/features/device/components/filter-popover";
 
@@ -74,7 +74,7 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
       <main>
         <SearchProvider>
           <div className="flex justify-end pb-5 lg:hidden">
-            <ButtonActions />
+            <DeviceButtonActions />
           </div>
           <ButtonGroup className="w-full sm:pb-5">
             <ButtonGroup aria-label="Search Bar Group" className="hidden sm:flex">
@@ -99,7 +99,7 @@ export default async function DevicesPage({ searchParams }: DevicesPageProps) {
               <ClearFilterButton />
             </ButtonGroup>
             <ButtonGroup className="hidden lg:flex lg:grow lg:justify-end">
-              <ButtonActions />
+              <DeviceButtonActions />
             </ButtonGroup>
           </ButtonGroup>
           <ButtonGroup className="w-full pt-2 pb-5 sm:hidden">

--- a/src/features/device/components/button-actions.tsx
+++ b/src/features/device/components/button-actions.tsx
@@ -26,7 +26,10 @@ export default function ButtonActions() {
 
   return (
     <>
-      <NewDeviceLink />
+      <Link href={NEW_DEVICE_PATH} className={cn(buttonVariants({ variant: "outline" }), "border")}>
+        <PlusIcon />
+        New Device
+      </Link>
       <DropdownMenu>
         <Tooltip>
           <TooltipTrigger
@@ -62,14 +65,5 @@ export default function ButtonActions() {
         </DropdownMenuContent>
       </DropdownMenu>
     </>
-  );
-}
-
-function NewDeviceLink() {
-  return (
-    <Link href={NEW_DEVICE_PATH} className={cn(buttonVariants({ variant: "outline" }), "border")}>
-      <PlusIcon />
-      New Device
-    </Link>
   );
 }

--- a/src/features/device/components/button-actions.tsx
+++ b/src/features/device/components/button-actions.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 
 import { DownloadCloudIcon, ImportIcon, MoreHorizontalIcon, PlusIcon } from "lucide-react";
 
+import { cn } from "@/lib/utils";
+
 import { NEW_DEVICE_PATH } from "@/features/dashboard/lib/constants";
 
 import useDownloadDevices from "@/features/device/hooks/use-download-devices";
@@ -58,7 +60,7 @@ export default function ButtonActions() {
 
 function NewDeviceLink() {
   return (
-    <Link href={NEW_DEVICE_PATH} className={buttonVariants({ variant: "outline" })}>
+    <Link href={NEW_DEVICE_PATH} className={cn(buttonVariants({ variant: "outline" }), "border")}>
       <PlusIcon />
       New Device
     </Link>

--- a/src/features/device/components/button-actions.tsx
+++ b/src/features/device/components/button-actions.tsx
@@ -10,7 +10,7 @@ import { NEW_DEVICE_PATH } from "@/features/dashboard/lib/constants";
 
 import useDownloadDevices from "@/features/device/hooks/use-download-devices";
 
-import { buttonVariants } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -32,8 +32,15 @@ export default function ButtonActions() {
           <TooltipTrigger
             render={
               <DropdownMenuTrigger
-                aria-label="More Options"
-                className={buttonVariants({ variant: "outline", size: "icon", className: "border-l-0" })}
+                render={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    aria-label="More Options"
+                    className="border-l-0"
+                  />
+                }
               >
                 <MoreHorizontalIcon />
               </DropdownMenuTrigger>

--- a/src/features/device/components/device-button-actions.tsx
+++ b/src/features/device/components/device-button-actions.tsx
@@ -27,7 +27,7 @@ export default function DeviceButtonActions() {
   return (
     <>
       <Link href={NEW_DEVICE_PATH} className={cn(buttonVariants({ variant: "outline" }), "border")}>
-        <PlusIcon />
+        <PlusIcon data-icon="inline-start" />
         New Device
       </Link>
       <DropdownMenu>

--- a/src/features/device/components/device-button-actions.tsx
+++ b/src/features/device/components/device-button-actions.tsx
@@ -21,7 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-export default function ButtonActions() {
+export default function DeviceButtonActions() {
   const { handleDownload } = useDownloadDevices();
 
   return (

--- a/src/features/device/components/edit-device-button.tsx
+++ b/src/features/device/components/edit-device-button.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { EditIcon } from "lucide-react";
+
 import type { Device, DeviceItem } from "@/features/device/lib/definitions";
 
 import useModal from "@/features/device/hooks/use-modal";
@@ -21,6 +23,7 @@ export default function EditDeviceButton({ device, types, statuses, groups }: Ed
   return (
     <>
       <Button type="button" variant="outline" onClick={() => setModal("edit")}>
+        <EditIcon data-icon="inline-start" />
         Edit Device
       </Button>
       {modal === "edit" && (


### PR DESCRIPTION
This PR makes modifications to the button actions via the device pages. It also fixes an issue where the outline of the button group via the device page was not visible in light mode.

## Changes
- Fixed button group outline not showing in light mode.
- Updated the way the action button via the devices page is rendered via the drop-down menu trigger.
- Moved the new device link component to the device button actions component.
- Added `data-icon="inline-start"` to the icon via the add device button via the devices page.
- Added an icon to the edit device button via the device details page.