### PR TITLE
Prevent content from auto zooming on input focus

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 
 import { Geist } from "next/font/google";
 
@@ -25,6 +25,10 @@ export const metadata: Metadata = {
     default: APP_NAME,
   },
   description: APP_DESCRIPTION,
+};
+
+export const viewport: Viewport = {
+  maximumScale: 1,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
This PR modifies the meta viewport to prevent iOS devices from auto zooming on input focus. The auto zoom occurs when the font size of input elements is smaller than 16 pixels.

## Changes
- Added a `viewport` constant to the main layout and added `maximumScale` with a value of 1.